### PR TITLE
Fix template installation instructions for dotnet core

### DIFF
--- a/wwwroot/guides/quickstart.md
+++ b/wwwroot/guides/quickstart.md
@@ -20,7 +20,7 @@ For more information see [the tutorial](https://github.com/grokys/Pizzalonia).
 
 ## .NET Core
 
-First install the Avalonia templates for .NET Core by following the instructions [here](https://github.com/AvaloniaUI/avalonia-dotnet-templates)
+First install the Avalonia templates for .NET Core by following the instructions [here](https://github.com/AvaloniaUI/avalonia-dotnet-templates).
 
 This will add a couple of project templates to `dotnet`:
 

--- a/wwwroot/guides/quickstart.md
+++ b/wwwroot/guides/quickstart.md
@@ -20,11 +20,7 @@ For more information see [the tutorial](https://github.com/grokys/Pizzalonia).
 
 ## .NET Core
 
-First install the Avalonia templates for .NET Core:
-
-```powershell
-dotnet install -i Avalonia.Templates.NetCore
-```
+First install the Avalonia templates for .NET Core by following the instructions [here](https://github.com/AvaloniaUI/avalonia-dotnet-templates)
 
 This will add a couple of project templates to `dotnet`:
 


### PR DESCRIPTION
The previous instructions were wrong (you need to use "dotnet new -i", not "dotnet install -i" and the templates no longer (never?) existed in Nuget, redirecting to the template repo which has a functional explanation of installation.