### PR TITLE
Numerous markdown fixes.

### DIFF
--- a/wwwroot/architecture/nuget.md
+++ b/wwwroot/architecture/nuget.md
@@ -1,4 +1,5 @@
-# Avalonia NuGet Packages
+Title: Avalonia NuGet Packages
+---
 
 Avalonia is divided into several `NuGet` packages. 
 
@@ -8,7 +9,7 @@ Avalonia is divided into several `NuGet` packages.
 * The `Avalonia.iOS` and `Avalonia.Android` packages are intended to be used by the end users targeting specific mobile platforms. 
 * The `Avalonia.Mobile` package is intended to be used by the end users targeting multiple mobile platforms (`Android` and `iOS`).
 
-## Core
+# Core
 
 * Avalonia (.nupkg)
   - Avalonia.Animation (.dll)
@@ -34,7 +35,7 @@ Avalonia is divided into several `NuGet` packages.
 * Avalonia.HtmlRenderer (.nupkg)
   - Avalonia (.nupkg)
 
-## Desktop
+# Desktop
 
 * Avalonia.Win32 (.nupkg)
   - Avalonia.Win32 (.dll)
@@ -67,7 +68,7 @@ Avalonia is divided into several `NuGet` packages.
   - Avalonia.Cairo (.nupkg)
   - Avalonia.Skia.Desktop (.nupkg)
 
-## Mobile
+# Mobile
 
 * Avalonia.Android (.nupkg)
   - Avalonia.Android (.dll)

--- a/wwwroot/architecture/project-structure.md
+++ b/wwwroot/architecture/project-structure.md
@@ -1,4 +1,5 @@
-# Avalonia Architecture
+Title: Avalonia Architecture
+---
 
 At the highest level, avalonia is split up into a "core" and two "subsystems".
 
@@ -8,17 +9,17 @@ At the highest level, avalonia is split up into a "core" and two "subsystems".
 
 There are currently two Windowing and two Rendering subsystems:
 
-## Windowing Subsystems
+# Windowing Subsystems
 
 * Avalonia.Win32 uses the Win32 API (this also works on 64-bit windows).
 * Avalonia.Gtk uses the GTK2 toolkit and can be run on both Windows and *nix.
 
-## Rendering Subsystems
+# Rendering Subsystems
 
 * Avalonia.Direct2D1 uses Microsoft's Direct2D1 API.
 * Avalonia.Cairo uses Cairo for rendering and Pango for text layout.
 
-## Core
+# Core
 
 The Avalonia core is split up into several assemblies. Note that they're not separated like this 
 because you will want to use them separately; they are separate to maintain separation of concerns 

--- a/wwwroot/assets/css/override.less
+++ b/wwwroot/assets/css/override.less
@@ -20,10 +20,11 @@
 }
 
 .disclaimer {
-    padding: 20px;
-    background-color: #f44336; /* Red */
+    padding: 15px;
+    background-color: #bb2419;
     color: white;
-    margin: 15px;
+    margin: 10px;
+    font-weight: bold;
 }
 
 .content a {

--- a/wwwroot/assets/css/override.less
+++ b/wwwroot/assets/css/override.less
@@ -19,6 +19,13 @@
     margin: 12px auto;
 }
 
+.disclaimer {
+    padding: 20px;
+    background-color: #f44336; /* Red */
+    color: white;
+    margin: 15px;
+}
+
 .content a {
     text-decoration: underline;
 }

--- a/wwwroot/blog/2015-02-16-avalonia-properties.md
+++ b/wwwroot/blog/2015-02-16-avalonia-properties.md
@@ -98,7 +98,7 @@ Note, `AvaloniaObject` is defined at a lower level than the concept of "parent c
 This is automatically set by `Visual` (which inherits from `AvaloniaObject`) so you shouldn't usually
 have to worry about it.
 
-## Attached Properties
+# Attached Properties
 
 Attached properties are essentially the same as attached dependency properties in WPF. They are
 defined by calling `AvaloniaProperty.RegisterAttached`:
@@ -108,7 +108,7 @@ public static readonly AvaloniaProperty<int> ColumnProperty =
     AvaloniaProperty.RegisterAttached<Grid, Control, int>("Column");
 ```
 
-## Default Values
+# Default Values
 
 Default values are provided in the call to `AvaloniaProperty.Register` or `RegisterAttached`. If no
 default value is provided the default is taken to be `default(TValue)`.
@@ -125,7 +125,7 @@ FooProperty.OverrideDefaultValue(typeof(AnotherControl), 64);
 ```
 
 
-## Coercion
+# Coercion
 
 Coercion allows a control to react to changes in a property's value and make sure that the value is
 within a valid range. For example a "Percentage" property may only allow values between 0 and 100:

--- a/wwwroot/blog/2015-09-21-avalonia-alpha2.md
+++ b/wwwroot/blog/2015-09-21-avalonia-alpha2.md
@@ -16,7 +16,7 @@ current progress:
 Here are some of the highlights of this release - we've come a long way in the
 3 weeks since alpha 1!
 
-## Visual Studio Designer
+# Visual Studio Designer
 
 [Nikita Tsukanov](https://github.com/kekekeks) and [Darnell Williams](https://github.com/ImaBrokeDude) have done the impossible and
 got a basic designer for Visual Studio working. It's still early days and not
@@ -24,7 +24,7 @@ everything is supported yet, but it's a massive step towards a user-friendly
 designer experience with Avalonia. Take a look at the video above to see it in
 action or download the [VS Plugin](https://visualstudiogallery.msdn.microsoft.com/a4542e8a-b56c-4295-8df1-7e220178b873)
 
-## Styles in XAML
+# Styles in XAML
 
 We've added support for expressing styles in XAML.
 
@@ -43,18 +43,18 @@ To see more examples of what you can do with Avalonia styles, [check out the doc
 
 Of course, our XAML support is only available thanks to [OmniXAML](https://github.com/superjmn/omnixaml)!
 
-## \*Nix support
+# \*Nix support
 
 Avalonia now runs on \*nix platforms using mono - this includes Linux and Mac
 OSX. For information on building Avalonia on \*nix take a look at the [build
 instructions](https://github.com/Avalonia/Avalonia/blob/master/docs/build.md).
 
-## HTML View
+# HTML View
 
 As well as doing the impossible once with the designer, [Nikita Tsukanov](https://github.com/kekekeks) has also ported the [HTML Renderer](https://htmlrenderer.codeplex.com/) component to Avalonia, giving us a
 100% managed HTML 4.01 and CSS 2 renderer directly in Avalonia.
 
-## New Controls Showcase
+# New Controls Showcase
 
 ![Controls Showcase](/blog/2015-09-21-avalonia-alpha2/controls-showcase.png)
 
@@ -63,7 +63,7 @@ backend into shape) has contributed a new controls showcase to Avalonia. This
 is a lot better looking than our previous cobbled-togther test application and
 should give a good idea of what Avalonia is capable of at the moment.
 
-## New Features
+# New Features
 
 The following new features have been implemented:
 
@@ -73,11 +73,11 @@ The following new features have been implemented:
 - Canvas (thanks to [Amer Koleci](https://github.com/amerkoleci))
 - Cursor support
 
-## Nightly NuGet packages
+# Nightly NuGet packages
 
 We are now hosting nightly NuGet packages on [MyGet](https://www.myget.org/F/avalonia-nightly/api/v2/Packages).
 
-## Join us
+# Join us
 
 If you're wanting to join in, take a look at the [`up-for-grabs` issues on
 GitHub](https://github.com/Avalonia/Avalonia/labels/up-for-grabs) - these issues

--- a/wwwroot/blog/2015-12-03-avalonia-alpha3.md
+++ b/wwwroot/blog/2015-12-03-avalonia-alpha3.md
@@ -35,7 +35,7 @@ XAML binding was rather buggy and lacking in features in the last alpha, but
 should now be a lot more usable. We've also added some features above and beyond
 traditional XAML binding:
 
-## Binding to Controls
+# Binding to Controls
 
 You can now bind to controls:
 
@@ -49,7 +49,7 @@ But in addition we also have the shorthand form of:
     <TextBox Text={Binding #other.Text}
 ```
 
-## Binding negation
+# Binding negation
 
 Ever lamented the hoops you have to jump though in XAML to negate a binding?
 Well we feel your pain and now you can negate bindings just by adding a `!`
@@ -61,7 +61,7 @@ to the binding path:
     <ContentPresenter Content="{Binding}" IsVisible="{Binding !Loading}"/>
 ```
 
-## MultiBinding and Async Bindings
+# MultiBinding and Async Bindings
 
 We also have initial support for `MultiBinding` (only one-way at the moment) and
 you can also bind to `Task` and `Observable` and get the results you'd expect!

--- a/wwwroot/blog/2018-02-18-avalonia-beta1.md
+++ b/wwwroot/blog/2018-02-18-avalonia-beta1.md
@@ -24,7 +24,7 @@ There have been a few architectural changes in this release that we hope will ai
 
 So here's some of the major features in this release:
 
-## Deferred Rendering
+# Deferred Rendering
 
 We were previously rendering the entire window each time something changed, which was obviously rather inefficient. [#827](https://github.com/AvaloniaUI/Avalonia/pull/827) added a `DeferredRenderer`  which renders to a low-level scenegraph on the UI thread which is then rendered to the window on a separate render thread.
 
@@ -32,13 +32,13 @@ This greatly improves our rendering performance - particularly when animations a
 
 The old renderer is still available as the `ImmediateRenderer` class for those folks who want to render everything every frame.
 
-## Monomac-based Backend
+# Monomac-based Backend
 
 [#1005](https://github.com/AvaloniaUI/Avalonia/pull/1005) introduced a new Monomac-based backend for Mac OSX platforms. 
 The main issue with GTK2/GTK3 backends used previously was the huge set of binaries (~60MB) that needs to be shipped with your app. Another problem with those binaries is that it's complicated to package them into your app bundle.
 Our new backend also makes use of Cocoa window dialogs, which makes your app to look more native.
 
-## Relative Source Syntax Sugar
+# Relative Source Syntax Sugar
 
 [#1209](https://github.com/AvaloniaUI/Avalonia/pull/1209) introduced shorthand for binding to other controls relative to the control being bound. In WPF, this is achieved by using the `RelativeSource` syntax on a `{Binding}`, as a (slightly contrived example) this is how you would bind a `TextBlock`'s text to the `Tag` property on a parent control:
 
@@ -67,25 +67,25 @@ Now Avalonia has new syntax to achieve this without the verbosity:
 | `$parent[ns:Type]`        | `Mode = FindAncestor; AncestorType = ns:Type` |
 | `$parent[ns:Type; Level]` | `Mode = FindAncestor; AncestorType = ns:Type; AncestorLevel = Level + 1` |
 
-## Drawings
+# Drawings
 
 `Drawing` is a convenient way to create vector icons, used by WPF. The [Visual Studio Image Library](https://msdn.microsoft.com/en-us/library/windows/desktop/mt791579(v=vs.85).aspx) provides many icons as Drawings, and there are other tools that can produce them. They are much more lightweight compared to `Shape` controls since they are not part of the visual tree. 
 
 [1117](https://github.com/AvaloniaUI/Avalonia/pull/1117) added support for Drawings to Avalonia, though our standard image control still can't display them - in the meantime while we add support for that, drawings can be displayed in a `DrawingPresenter` control.
 
-## New Previewer with .NET Core support in Visual Studio extension
+# New Previewer with .NET Core support in Visual Studio extension
 
 [#1105](https://github.com/AvaloniaUI/Avalonia/pull/1105) introduced a new previewer architecture which should allow us to make designers for non-windows platforms. The previous previewer used win32 API voodoo to reparent the window of the application into the designer. It also used some external executable that would initialize various things via reflection. The whole thing was tied to win32 and full .NET framework, it also made several assumptions about your app. The new previewer architecture instead uses a TCP transport protocol which communicates between the application and the designer in a platform-independent manner. It still has an option to embed the HWND which is used by our Visual Studio extension, but the default one will transfer rendered bitmap data via TCP. Speaking of which, the entire infrastructure for remote widgets is exposed in our public API via `RemoteServer` and `RemoteWidget` classes.
 
 The [AvaloniaVS](https://marketplace.visualstudio.com/items?itemName=AvaloniaTeam.AvaloniaforVisualStudio) extension has already been updated to use this new protocol, and hopefully now designers for other IDEs will be coming soon!
 
-## StaticResource and DynamicResource
+# StaticResource and DynamicResource
 
 [#1130](https://github.com/AvaloniaUI/Avalonia/pull/1130) added `Control.Resources`, `StaticResource` and `DynamicResource`.
 
 The new features are designed to follow WPF/UWP as closely as possible - previously, resources could only be contained in `<Style>`s and we used `{StyleResource}` to access these resources. Now each control has its own `Resources` dictionary and `{StaticResource}` and `{DynamicResource}` are used to access them. `{StyleResource}` has now be removed, so you will need to update all uses of that markup extension to `{DynamicResource}`.
 
-## Bind Commands to Methods
+# Bind Commands to Methods
 
 Ever get annoyed that you have to create an `ICommand` to bind a button command, and wish you could just point your binding to a method? Since [`#1179`](https://github.com/AvaloniaUI/Avalonia/pull/1179) you can! 
 
@@ -103,16 +103,16 @@ public class ViewModel
 <Button Command="{Binding ButtonClicked}"/>
 ```
 
-## Calendar Control
+# Calendar Control
 
 [#1244](https://github.com/AvaloniaUI/Avalonia/pull/1244) ported the [Silverlight Calendar](https://github.com/MicrosoftArchive/SilverlightToolkit) control to Avalonia, for all your calendaring needs.
 
-## WPF integration
+# WPF integration
 
 We've added a seamless integration with WPF: you can embed Avalonia controls in your WPF application without creating extra native windows and with full layout integration which is allowed by the fact that WPF's and Avalonia's layout systems are almost the same. See the demo [here](https://www.youtube.com/watch?v=uFKcO3RxN7k).
 
 
-## Various Other Features
+# Various Other Features
 
 Here's a curated list of the other interesting features that were introduced in this release. To see everything included in the Beta 1 release, see the [milestone](https://github.com/AvaloniaUI/Avalonia/milestone/2).
 
@@ -132,11 +132,11 @@ Here's a curated list of the other interesting features that were introduced in 
 - `#1079` Portablexaml
 
 
-## Breaking changes in this release
+# Breaking changes in this release
 
 We are also now tracking breaking changes at our [wiki page](https://github.com/AvaloniaUI/Avalonia/wiki/Breaking-Changes).
 
-### `BuildAvaloniaApp` and previewer.
+## `BuildAvaloniaApp` and previewer.
 
 You now need `BuildAvaloniaApp` static method in the class with your entry point (typically in `Program.cs` or `App.xaml.cs`) which should be called from `Main`:
 
@@ -155,20 +155,20 @@ You now need `BuildAvaloniaApp` static method in the class with your entry point
 
 Previewer *won't* be able to work without it.
 
-### `DataContextChanging` and `DataContextChanged`
+## `DataContextChanging` and `DataContextChanged`
 
 They were replaced by `OnDataContextBeginUpdate` and `OnDataContextEndUpdate`
 
 
-### `Static` and `Type` markup extensions
+## `Static` and `Type` markup extensions
 
 They were replaced by standard `x:Static` and `x:Type`, add `xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"` to the root of your XAML file.
 
-### `StyleResource`
+## `StyleResource`
 
 `StyleResource` has been replaced by `StaticResource` and `DynamicResource` as in other XAML frameworks. `StaticResource` and `DynamicResource` in Avalonia search both `Control.Resources` _and_ `Style.Resources`.
 
-### Mouse device
+## Mouse device
 
 `MouseDevice` is no longer available from the global context, you need to obtain one from `TopLevel` (`Window`, `Popup`, etc). Call `GetVisualRoot()` in your control and cast it to `IInputRoot`.
 
@@ -177,7 +177,7 @@ var pos = (_control.GetVisualRoot() as IInputRoot)?.MouseDevice?.Position ?? def
 ```
 
 
-## Getting started
+# Getting started
 
 Follow instructions [here](/guides/quickstart).
 

--- a/wwwroot/blog/2018-10-09-avalonia-native-osx.md
+++ b/wwwroot/blog/2018-10-09-avalonia-native-osx.md
@@ -10,7 +10,7 @@ For the past few months we have been working on a new backend for OSX. We now ha
 
 Currently we are publishing the new backend as a seperate nuget package. The OSX backend now supports OpenGL GPU acceleration.
 
-## Try the new Mac Backend today
+# Try the new Mac Backend today
 
 To try the new backend today you need to update your application to Avalonia version `0.6.2-build6362-beta` for information on how to use Avalonia nightly builds see: [Using nightly build feed](https://github.com/AvaloniaUI/Avalonia/wiki/Using-nightly-build-feed)
 
@@ -47,7 +47,7 @@ I recommend doing this by replacing the BuildAvaloniaApp method like so:
 
 ```
 
-## What is Avalonia.Native?
+# What is Avalonia.Native?
 
 Avalonia.Native isn't just an Avalonia backend for OSX, it is actually set of COM based interfaces that Avalonia can attach to. This allows Avalonia  backends to be written in native code on platforms where this is difficult in managed code.
 

--- a/wwwroot/contributing/build.md
+++ b/wwwroot/contributing/build.md
@@ -1,39 +1,40 @@
-# Building Avalonia
+Title: Building Avalonia
+---
 
-## Windows
+# Windows
 
 Avalonia requires at least Visual Studio 2017 and .NET Core SDK 2.0 to build on Windows.
 
-### Clone the Avalonia repository
+###  Clone the Avalonia repository
 
 ```
 git clone https://github.com/AvaloniaUI/Avalonia.git
 git submodule update --init
 ```
 
-### Open in Visual Studio
+###  Open in Visual Studio
 
 Open the `Avalonia.sln` solution in Visual Studio 2015 or newer. The free Visual Studio Community
 edition works fine. Run the `Samples\ControlCatalog.Desktop` project to see the sample application.
 
-## Linux/OSX
+# Linux/OSX
 
 It's *not* possible to build the *whole* project on Linux/OSX. You can only build the subset targeting .NET Standard and .NET Core (which is, however, sufficient to get UI working on Linux/OSX). If you want to something that involves changing platform-specific APIs you'll need a Windows machine.
 
 MonoDevelop, Xamarin Studio and Visual Studio for Mac aren't capable of properly opening our solution. You can use Rider (at least 2017.2 EAP) or VSCode instead. They will fail to load most of platform specific projects, but you don't need them to run on .NET Core.
 
-### Install the latest version of .NET Core
+###  Install the latest version of .NET Core
 
 Go to https://www.microsoft.com/net/core and follow instructions for your OS. You need SDK (not just "runtime") package.
 
-### Clone the Avalonia repository
+###  Clone the Avalonia repository
 
 ```
 git clone https://github.com/AvaloniaUI/Avalonia.git
 git submodule update --init --recursive
 ```
 
-### Build and Run Avalonia
+###  Build and Run Avalonia
 
 ```
 samples/ControlCatalog.NetCore

--- a/wwwroot/contributing/contributing.md
+++ b/wwwroot/contributing/contributing.md
@@ -1,10 +1,11 @@
-# Contributing #
+Title: Contributing
+---
 
-## Before You Start ##
+# Before You Start 
 
 Drop into our [gitter chat room](https://gitter.im/AvaloniaUI/Avalonia) and let us know what you're thinking of doing. We might be able to give you guidance or let you know if someone else is already working on the feature.
 
-## Style ##
+# Style
 
 The codebase uses [.net core](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md) coding style. 
 
@@ -13,7 +14,7 @@ If you're a few characters over then don't worry too much.
 
 **DO NOT USE #REGIONS** full stop.
 
-## Pull requests ##
+# Pull requests
 
 A single pull request should be submitted for each change. If you're making more than one change,
 please submit separate pull requests for each change for easy review. Rebase your changes to make 
@@ -39,7 +40,7 @@ new features!
 
 Prefer terseness to verbosity but don't try to be too clever.
 
-## Tests ##
+# Tests
 
 There are two types of tests currently in the codebase; unit tests and render tests.
 
@@ -53,8 +54,12 @@ Where Avalonia.Controls.UnitTests is the name of the project.
 Unit test methods should be named in a sentence style, separated by underscores, that describes in
 English what the test is testing, e.g.
 
+```C#
     void Calling_Foo_Should_Increment_Bar()
+```
 
 Render tests should describe what the produced image is:
 
+```C#
     void Rectangle_2px_Stroke_Filled()
+```

--- a/wwwroot/docs/animations/index.md
+++ b/wwwroot/docs/animations/index.md
@@ -2,6 +2,10 @@ Title: Animations
 Order: 0
 ---
 
+<div class="disclaimer">
+The following features are only available on nightly builds and to the upcoming 0.7 release.
+</div>
+
 There are two types of animations in Avalonia:
 
 - [Keyframe animations](keyframe.md) animate any number of properties on a control, using any

--- a/wwwroot/docs/animations/index.md
+++ b/wwwroot/docs/animations/index.md
@@ -3,7 +3,7 @@ Order: 0
 ---
 
 <div class="disclaimer">
-The following features are only available on nightly builds and to the upcoming 0.7 release.
+    &#9888;&#65039; The following features are only available on nightly builds and to the upcoming 0.7 release.
 </div>
 
 There are two types of animations in Avalonia:

--- a/wwwroot/docs/animations/keyframe.md
+++ b/wwwroot/docs/animations/keyframe.md
@@ -38,7 +38,7 @@ Keyframe animations are applied using styles. They can be defined on any style b
 The example above animates the target `Control` as defined by its [selector](/docs/styles/selectors).
 It will be run immediately when the control is loaded.
 
-## Triggering Animations
+# Triggering Animations
 
 Unlike WPF's `Triggers`, Animations defined in XAML rely on [selectors](/docs/styles/selectors) for 
 their triggering behavior. Selectors can always apply to a control, or they can conditionally apply
@@ -48,7 +48,7 @@ If the selector isn't conditional then the animation will be triggered when a ma
 spawned into the visual tree. Otherwise, the animations will run whenever its selector is activated.
 When the selector no longer matches, the currently running animation will be canceled.
 
-## `KeyFrames`
+# `KeyFrames`
 
 The `KeyFrame` objects defines when the target `Setter` objects should be applied on the target `Control`, 
 with value interpolation in-between.
@@ -75,7 +75,7 @@ desired `KeyFrame`:
 </Animation>
 ```
 
-## Delay
+# Delay
 
 You can add a delay in a `Animation` by defining the desired delay time on its `Delay` property:
 
@@ -86,7 +86,7 @@ You can add a delay in a `Animation` by defining the desired delay time on its `
 </Animation>
 ```
 
-## Repeat
+# Repeat
 
 You can set the following repeat behaviors on `RepeatCount` property of an `Animation`.
 
@@ -96,7 +96,7 @@ You can set the following repeat behaviors on `RepeatCount` property of an `Anim
 |`1` to N|Repeat N times.|
 |`Loop`|Repeat Indefinitely|
 
-## Playback Direction
+# Playback Direction
 
 The `PlaybackDirection` property defines how should the animation be played, including repeats.
 
@@ -109,7 +109,7 @@ The following table describes the possible behaviors:
 |`Alternate`|The animation is played forwards first, then backwards.|
 |`AlternateReverse`|The animation is played backwards first, then forwards.|
 
-## Value fill modes
+# Value fill modes
 
 The `FillMode` property defines whether the first or last interpolated value of an animation
 persist before or after running an animation and on delays in-between runs. 
@@ -123,7 +123,7 @@ The following table describes the possible behaviors:
 |`Backward`|The first interpolated value will be displayed on animation delay.|
 |`Both`|Both `Forward` and `Backward` behaviors will be applied.|
 
-## Easings
+# Easings
 
 Easing functions can be set by setting the name of the desired function to the `Animation`'s `Easing` property:
 

--- a/wwwroot/docs/animations/keyframe.md
+++ b/wwwroot/docs/animations/keyframe.md
@@ -3,7 +3,7 @@ Order: 10
 ---
 
 <div class="disclaimer">
-The following features are only available on nightly builds and to the upcoming 0.7 release.
+    &#9888;&#65039; The following features are only available on nightly builds and to the upcoming 0.7 release.
 </div>
 
 Keyframe animations in Avalonia are heavily inspired by CSS Animations. They can be used to animate

--- a/wwwroot/docs/animations/keyframe.md
+++ b/wwwroot/docs/animations/keyframe.md
@@ -2,6 +2,10 @@ Title: Keyframe Animations
 Order: 10
 ---
 
+<div class="disclaimer">
+The following features are only available on nightly builds and to the upcoming 0.7 release.
+</div>
+
 Keyframe animations in Avalonia are heavily inspired by CSS Animations. They can be used to animate
 any number of properties on a control, using any number of keyframes to define the states that each
 property must pass through. Keyframe animations can run any number of times, in either direction.

--- a/wwwroot/docs/animations/transitions.md
+++ b/wwwroot/docs/animations/transitions.md
@@ -3,7 +3,7 @@ Order: 20
 ---
 
 <div class="disclaimer">
-The following features are only available on nightly builds and to the upcoming 0.7 release.
+    &#9888;&#65039; The following features are only available on nightly builds and to the upcoming 0.7 release.
 </div>
 
 Transitions in Avalonia are also heavily inspired by CSS Animations. They listen to any changes in target property's value 

--- a/wwwroot/docs/animations/transitions.md
+++ b/wwwroot/docs/animations/transitions.md
@@ -1,6 +1,11 @@
 Title: Transitions
 Order: 20
 ---
+
+<div class="disclaimer">
+The following features are only available on nightly builds and to the upcoming 0.7 release.
+</div>
+
 Transitions in Avalonia are also heavily inspired by CSS Animations. They listen to any changes in target property's value 
 and subsequently animates the change according to its parameters. They can be defined on any `Control` via `Transitions` property:
 

--- a/wwwroot/docs/authoring-controls/defining-properties.md
+++ b/wwwroot/docs/authoring-controls/defining-properties.md
@@ -6,7 +6,7 @@ If you are creating a control, you will want to define properties on your contro
 by defining `AvaloniaProperty`s for your control. Avalonia properties consist of two parts: the
 property definition and the CLR getter/setter for the property.
 
-## Registering Styled Properties
+# Registering Styled Properties
 
 Unless you have a good reason not to, you should define properties on your control as _styled
 properties_. Styled properties ensure that your property will work correctly with Avalonia's
@@ -45,7 +45,7 @@ or throws an exception for an invalid value.
 
 > A styled property is analogous to a `DependencyProperty` in other XAML frameworks.
 
-## Using a `StyledProperty` on Another Class
+# Using a `StyledProperty` on Another Class
 
 Sometimes the property you want to add to your control already exists on another
 control, `Background` being a good example. To register a property defined on
@@ -66,7 +66,7 @@ another control, you call `StyledProperty.AddOwner`:
 > Note: Unlike WPF/UWP, a property must be registered on a class otherwise it cannot
   be set on an object of that class. This may change in future, however.
 
-## Readonly Properties
+# Readonly Properties
 
 To create a readonly property you use the `AvaloniaProperty.RegisterDirect`
 method. Here is how `Visual` registers the readonly `Bounds` property:
@@ -91,7 +91,7 @@ registering the property, a getter is passed which is used to access the
 property value through `GetValue` and then `SetAndRaise` is used to notify
 listeners to changes to the property.
 
-## Attached Properties
+# Attached Properties
 
 Attached properties are defined almost identically to styled properties except
 that they are registered using the `RegisterAttached` method and their accessors
@@ -114,7 +114,7 @@ Here's how `Grid` defines its `Grid.Column` attached property:
     }
 ```
 
-## Direct AvaloniaProperties
+# Direct AvaloniaProperties
 
 As its name suggests, `RegisterDirect` isn't just used for registering readonly
 properties. You can also pass a *setter* to `RegisterDirect` to expose a
@@ -162,7 +162,7 @@ They don't support the following:
 - Overriding default values.
 - Inherited values
 
-## Using a DirectProperty on Another Class
+# Using a DirectProperty on Another Class
 
 In the same way that you can call `AddOwner` on a styled property, you can also
 add an owner to a direct property. Because direct properties reference fields
@@ -183,7 +183,7 @@ on the control, you must also add a field for the property:
     }
 ```
 
-## When to use a Direct vs a Styled Property
+# When to use a Direct vs a Styled Property
 
 In general you should declare your properties as styled properties. However, direct properties have
 advantages and disadvantages:

--- a/wwwroot/docs/authoring-controls/types-of-control.md
+++ b/wwwroot/docs/authoring-controls/types-of-control.md
@@ -4,14 +4,14 @@ Order: 0
 If you want to create your own controls, there are three main categories of control in Avalonia.
 The first thing to do is choose the category of control that best suits your use-case.
 
-## User Controls
+# User Controls
 
 `UserControl`s are the simplest way to author controls. This type of control is best for "views"
 or "pages" that are specific to an application. `UserControl`s are authored in the same way as
 you would author a `Window`: by creating a new `UserControl` from a template and adding controls
 to it.
 
-## Templated Controls
+# Templated Controls
 
 `TemplatedControl`s are best used for generic controls that can be shared among various
 applications. They are _lookless_ controls, meaning that they can be restyled for different themes
@@ -20,7 +20,7 @@ and applications. The majority of standard controls defined by Avalonia fit into
 > In WPF/UWP you would inherit from the Control class to create a new templated control, but in
   Avalonia you should inherit from `TemplatedControl`.
 
-## Basic Control
+# Basic Control
 
 Basic `Control`s are the foundation of user interfaces - they draw themselves using geometry by
 overriding the `Visual.Render` method. Controls such as `TextBlock` and `Image` fall into this

--- a/wwwroot/docs/binding/binding-from-code.md
+++ b/wwwroot/docs/binding/binding-from-code.md
@@ -6,7 +6,7 @@ Binding from code in Avalonia works somewhat differently to WPF/UWP. At the low 
 binding system is based on Reactive Extensions' `IObservable` which is then built upon by XAML
 bindings (which can also be instantiated in code).
 
-## Subscribing to Changes to a Property
+# Subscribing to Changes to a Property
 
 You can subscribe to changes on a property by calling the `GetObservable`
 method. This returns an `IObservable<T>` which can be used to listen for changes
@@ -40,7 +40,7 @@ operator:
     var text = textBlock.GetObservable(TextBlock.TextProperty).Skip(1);
 ```
 
-## Binding to an observable
+# Binding to an observable
 
 You can bind a property to an observable using the `AvaloniaObject.Bind` method:
 
@@ -58,7 +58,7 @@ source.OnNext("hello");
 source.OnNext("world!");
 ```
 
-## Setting a binding in an object initializer
+# Setting a binding in an object initializer
 
 It is often useful to set up bindings in object initializers. You can do this using the indexer:
 
@@ -90,7 +90,7 @@ Of course the indexer can be used outside object initializers too:
 textBlock2[!TextBlock.TextProperty] = textBlock1[!TextBlock.TextProperty];
 ```
 
-## Transforming binding values
+# Transforming binding values
 
 Because we're working with observables, we can easily transform the values we're binding!
 
@@ -104,7 +104,7 @@ var textBlock = new TextBlock
 };
 ```
 
-## Using XAML bindings from code
+# Using XAML bindings from code
 
 Sometimes when you want the additional features that XAML bindings provide, it's easier to use XAML bindings from code. For example, using only observables you could bind to a property on `DataContext` like this:
 
@@ -125,7 +125,7 @@ var textBlock = new TextBlock
 };
 ```
 
-## Subscribing to a Property on Any Object
+# Subscribing to a Property on Any Object
 
 The `GetObservable` method returns an observable that tracks changes to a property on a single
 instance. However, if you're writing a control you may want to implement an `OnPropertyChanged`

--- a/wwwroot/docs/binding/binding-to-commands.md
+++ b/wwwroot/docs/binding/binding-to-commands.md
@@ -41,7 +41,7 @@ namespace Example
 <Window>
 ```
 
-## CommandParameter
+# CommandParameter
 
 You can also pass a parameter to the command using the `CommandParameter` property:
 
@@ -73,7 +73,7 @@ namespace Example
 
 Like any other property, `CommandParameter` can also be bound.
 
-## Binding To Methods
+# Binding To Methods
 
 Sometimes you just want to call a method when a button is clicked without the ceremony of creating
 a command. You can do that too!

--- a/wwwroot/docs/binding/binding-to-controls.md
+++ b/wwwroot/docs/binding/binding-to-controls.md
@@ -9,7 +9,7 @@ controls.
   `DataContext`. If you want to bind to the control's `DataContext` then you'll need to
   specify that in the binding path.
 
-## Binding to a named control
+# Binding to a named control
 
 If you want to bind to a property on another named control, you can use the control name
 prefixed by a `#` character.
@@ -30,7 +30,7 @@ This is the equivalent to the long-form binding that will be familiar to WPF and
 
 Avalonia supports both syntaxes but the short-form `#` syntax is less verbose.
 
-## Binding to an Ancestor
+# Binding to an Ancestor
 
 You can bind to the logical parent of the target using the `$parent` symbol:
 

--- a/wwwroot/docs/binding/bindings.md
+++ b/wwwroot/docs/binding/bindings.md
@@ -29,7 +29,7 @@ An empty binding binds to DataContext itself
 We call the property on the control the binding _target_ and the property on the `DataContext` the
 binding _source_.
 
-## Binding Path
+# Binding Path
 
 The binding path above can be a single property, or it can be a chain of properties. For example
 if the object assigned to the `DataContext` has a `Student` property, and the value of this property
@@ -45,7 +45,7 @@ You can also include array/list indexers in binding paths:
 <TextBlock Text="{Binding Students[0].Name}"/>
 ```
 
-## Binding Modes
+# Binding Modes
 
 You can change the behavior of a `{Binding}` by specifing a binding `Mode`:
 

--- a/wwwroot/docs/binding/converting-binding-values.md
+++ b/wwwroot/docs/binding/converting-binding-values.md
@@ -2,7 +2,7 @@ Title: Converting Binding Values
 Order: 30
 ---
 
-## Negating Values
+# Negating Values
 
 Often you will need to negate a value that you're binding to. A frequent use for this is to show
 or hide and control or to enable/disable it. You can negate a binding value by prepending a "bang"
@@ -38,7 +38,7 @@ hide a control when a collection is empty:
 </Panel>
 ```
 
-## Binding Converters
+# Binding Converters
 
 For more advanced conversions, Avalonia supports
 [`IValueConverter `](https://docs.microsoft.com/en-gb/dotnet/api/system.windows.data.ivalueconverter?view=netframework-4.7.1)

--- a/wwwroot/docs/controls/border.md
+++ b/wwwroot/docs/controls/border.md
@@ -20,7 +20,7 @@ An example of a border with a red background, 2 pixel black border, 3 pixel corn
 </Border>
 ```
 
-## Common Properties
+# Common Properties
 
 |Property|Description|
 |--------|-----------|
@@ -30,6 +30,6 @@ An example of a border with a red background, 2 pixel black border, 3 pixel corn
 |`Child`|The child control to decorate|
 |`CornerRadius`|The radius of the border's rounded corners|
 
-## Pseudoclasses
+# Pseudoclasses
 
 None

--- a/wwwroot/docs/controls/button.md
+++ b/wwwroot/docs/controls/button.md
@@ -12,7 +12,7 @@ can be assigned or bound to the button's [`Command`](/api/Avalonia.Controls/Butt
 property. This command will be executed when the button is clicked. For more information see
 [binding to commands](/docs/binding/binding-to-commands.md).
 
-## Common Properties
+# Common Properties
 
 |Property|Description|
 |--------|-----------|
@@ -23,7 +23,7 @@ property. This command will be executed when the button is clicked. For more inf
 |`IsDefault`|When set, pressing the enter key clicks the button even if not focused|
 |`IsPressed`|Set when the button is depressed|
 
-## Pseudoclasses
+# Pseudoclasses
 
 |Pseudoclass|Description|
 |-----------|-----------|

--- a/wwwroot/docs/controls/menu.md
+++ b/wwwroot/docs/controls/menu.md
@@ -32,7 +32,7 @@ The text of the `MenuItem` is displayed by the `Header` property; the inner cont
 
 Separators are added by including a `Separator` control or a `MenuItem` with a header of `"-"`.
 
-## Menu Commands
+# Menu Commands
 
 Like `Button`, commands can be [bound](/docs/binding/binding-to-commands) to `MenuItem`s. The
 command will be executed when the menu item is clicked or selected with the keyboard:
@@ -48,7 +48,7 @@ command will be executed when the menu item is clicked or selected with the keyb
 > See the [Binding to Commands](/docs/binding/binding-to-commands) section for more information
   on binding to commands.
 
-## Menu Icons
+# Menu Icons
 
 A menu icon can be displayed by placing an `Image` in the `Icon` property:
 
@@ -60,7 +60,7 @@ A menu icon can be displayed by placing an `Image` in the `Icon` property:
     </MenuItem>
 ```
 
-## Checkboxes
+# Checkboxes
 
 Similarly, a `CheckBox` can be displayed in the `Icon` property to make the `MenuItem` checkable:
 

--- a/wwwroot/docs/logging.md
+++ b/wwwroot/docs/logging.md
@@ -1,4 +1,5 @@
-# Avalonia Logging
+Title: Avalonia Logging
+---
 
 Avalonia uses [Serilog](https://github.com/serilog/serilog) for logging via
 the Avalonia.Logging.Serilog assembly.
@@ -22,7 +23,7 @@ By default, this logging setup will write log messages with a severity of
 documentation](https://github.com/serilog/serilog/wiki/Configuration-Basics)
 for more information on the options here.
 
-## Areas
+# Areas
 
 Each Avalonia log message has an "Area" that can be used to filter the log to
 include only the type of events that you are interested in. These are currently:
@@ -44,7 +45,7 @@ SerilogLogger.Initialize(new LoggerConfiguration()
     .CreateLogger());
 ```
 
-## Removing Serilog
+# Removing Serilog
 
 If you don't want a dependency on Serilog in your application, simply remove
 the reference to Avalonia.Logging.Serilog and the code that initializes it. If

--- a/wwwroot/docs/quickstart/create-new-project.md
+++ b/wwwroot/docs/quickstart/create-new-project.md
@@ -1,7 +1,7 @@
 Title: Creating a new Avalonia Project
 Order: 0
 ---
-## Visual Studio
+# Visual Studio
 
 The easiest way to get started with Avalonia from Visual Studio is to [install the extension](https://marketplace.visualstudio.com/items?itemName=AvaloniaTeam.AvaloniaforVisualStudio) from the Visual Studio Marketplace.
 
@@ -19,7 +19,7 @@ Once you have an Avalonia application, two item templates will become available:
 - **Window**: Creates a new top-level [`Window`](../guides/controls/window.md)
 - **UserControl**: Create a new [`UserControl`](../guides/controls/usercontrol.md)
 
-## .NET Core
+# .NET Core
 
 First install the Avalonia templates for .NET Core by following the instructions [here](https://github.com/AvaloniaUI/avalonia-dotnet-templates).
 

--- a/wwwroot/docs/quickstart/from-wpf.md
+++ b/wwwroot/docs/quickstart/from-wpf.md
@@ -5,7 +5,7 @@ Order: 100
 Avalonia is in general very similar to WPF, but you will find differences. Here
 are the most common:
 
-## Styling
+# Styling
 
 The most obvious difference from other XAML frameworks is that Avalonia uses a
 [CSS-like styling system](styles). Styles aren't stored in a
@@ -22,7 +22,7 @@ collection:
         <TextBlock Classes="h1">Header</TextBlock>
     <UserControl>    
 
-## DataTemplates
+# DataTemplates
 
 As styles aren't stored  in `Resources`, neither are `DataTemplates`. Instead, 
 `DataTemplates` are placed in a `DataTemplates` collection on each control
@@ -48,13 +48,13 @@ cannot be done in WPF) and so the order of `DataTemplate`s can be important:
 so you need to place them from most-specific to least-specific as you would in
 code.
 
-## HierachicalDataTemplate
+# HierachicalDataTemplate
 
 WPF's `HierarchicalDataTemplate` is called `TreeDataTemplate` in Avalonia (as the
 former is difficult to type!). The two are almost entirely equivalent except
 that the `ItemTemplate` property is not present in Avalonia.
 
-## UIElement, FrameworkElement and Control
+# UIElement, FrameworkElement and Control
 
 WPF's `UIElement` and `FrameworkElement` are non-templated control base classes,
 which roughly equate to the Avalonia `Control` class. WPF's `Control` class on
@@ -67,7 +67,7 @@ So to recap:
 - `FrameworkElement`: `Control`
 - `Control`: `TemplatedControl`
 
-## DependencyProperty
+# DependencyProperty
 
 The Avalonia equivalent of `DependencyProperty` is `StyledProperty`, however
 Avalonia [has a richer property system than WPF](defining-properties.md),
@@ -75,7 +75,7 @@ and includes `DirectProperty` for turning standard CLR properties into Avalonia
 properties. The common base class of `StyledProperty` and `DirectProperty`
 is `AvaloniaProperty`.
 
-## Grid
+# Grid
 
 Column and row definitions can be specified in Avalonia using strings, avoiding
 the clunky syntax in WPF:
@@ -88,13 +88,13 @@ than `Grid`.
 
 We don't yet support `SharedSizeScope` in `Grid`.
 
-## ItemsControl
+# ItemsControl
 
 In WPF, `ItemsControl` and derived classes such as `ListBox` have two separate
 items properties: `Items` and `ItemsSource`. Avalonia however just has a single
 one: `Items`.
 
-## Tunnelling Events
+# Tunnelling Events
 
 Avalonia has tunnelling events (unlike UWP!) but they're not exposed via
 separate `Preview` CLR event handlers. To subscribe to a tunnelling event you
@@ -109,7 +109,7 @@ void OnPreviewKeyDown(object sender, KeyEventArgs e)
 }
 ```
 
-## Class Handlers
+# Class Handlers
 
 In WPF, class handlers for events can be added by calling
 [EventManager.RegisterClassHandler](https://msdn.microsoft.com/en-us/library/ms597875.aspx).
@@ -139,7 +139,7 @@ Notice that in WPF you have to add the class handler as a static method, whereas
 in Avalonia the class handler is not static: the notification is automatically
 directed to the correct instance.
 
-## PropertyChangedCallback
+# PropertyChangedCallback
 
 Listening to changes on DependencyProperties in WPF can be complex. When you
 register a `DependencyProperty` you can supply a static `PropertyChangedCallback`
@@ -150,7 +150,7 @@ In Avalonia, there is no `PropertyChangedCallback` at the time of registration,
 instead a class listener is [added to the control's static constructor in much
 the same way that event class listeners are added](working-with-properties.md#subscribing-to-a-property-on-any-object).
 
-## RenderTransforms and RenderTransformOrigin
+# RenderTransforms and RenderTransformOrigin
 
 RenderTransformOrigins are different in WPF and Avalonia: If you apply a `RenderTransform`, keep in mind that our default value for the RenderTransformOrigin is `RelativePoint.Center`. In WPF the default value is `RelativePoint.TopLeft` (0, 0). In controls like Viewbox (currently being developed) the same code will lead to a different rendering behavior:
 

--- a/wwwroot/docs/quickstart/intro-to-xaml.md
+++ b/wwwroot/docs/quickstart/intro-to-xaml.md
@@ -10,7 +10,7 @@ many UI framworks.
   or [Microsoft XAML documentation for UWP](https://docs.microsoft.com/en-us/windows/uwp/xaml-platform/xaml-overview) -
   many of the concepts are the same between frameworks.
 
-## Format of an Avalonia XAML File
+# Format of an Avalonia XAML File
 
 A basic Avalonia XAML file looks like this:
 
@@ -30,7 +30,7 @@ There are three parts to this file:
   namespace. This isn't strictly necessary, but you will probably need it for accessing certain
   features of the XAML language.
 
-## Declaring Controls
+# Declaring Controls
 
 Controls are added to the XAML by adding an XML element with the control's class name. For example
 to add a button as the child of the window you would write:
@@ -44,7 +44,7 @@ to add a button as the child of the window you would write:
 
 See the [controls documentation](/docs/controls) for a list of the controls included with Avalonia.
 
-## Setting Properties
+# Setting Properties
 
 You can set a property of a control by adding an XML attribute to an element. For example to create
 a button with a blue background you could write:
@@ -59,7 +59,7 @@ a button with a blue background you could write:
 You can also use _property element syntax_ for setting properties. For more information see the
 [WPF documentation](https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/xaml-overview-wpf#property-element-syntax).
 
-## Content Properties
+# Content Properties
 
 You may notice that the button above has its "Hello World!" content placed directly inside the XML
 element. This could also be written as a property using:
@@ -75,7 +75,7 @@ This is because [`Button.Content`](api/Avalonia.Controls/ContentControl/4B02A756
 _`[Content]` Property_ which means that any content placed inside its XML tag will be assigned to this
 property.
 
-## Binding
+# Binding
 
 You can bind a property using the `{Binding}` markup extension:
 

--- a/wwwroot/docs/styles/selectors.md
+++ b/wwwroot/docs/styles/selectors.md
@@ -2,7 +2,7 @@ Title: Selectors
 Order: 10
 ---
 
-## OfType
+# OfType
 
 ```xml
 <Style Selector="Button">
@@ -23,7 +23,7 @@ This selector does not match derived types. For that, use the [`Is`](#is) select
   your control which inherits from `Button` to be styled as a `Button`, then you can implement the
   `IStyleable.StyleKey` property on your class to return `typeof(Button)`.
 
-## Name
+# Name
 
 ```xml
 <Style Selector="#myButton">
@@ -36,7 +36,7 @@ new Style(x => x.OfType<Button>().Name("myButton"));
 
 Selects a control by its [`Name`](/api/Avalonia.Controls/Control/580076CD) property.
 
-## Class
+# Class
 
 ```xml
 <Style Selector=".large">
@@ -55,11 +55,11 @@ Selects a control with the specified style classes. Multiple classes should be s
 `.` character, or a `:` character in the case of pseudoclasses. If multiple classes are specified
 then the control must have all of the requested classes present in order to match.
 
-## Is
+# Is
 
 ```xml
-<Style Selector="is(Button)">
-<Style Selector="is(local|Button)">
+<Style Selector=":is(Button)">
+<Style Selector=":is(local|Button)">
 ```
 ```csharp
 new Style(x => x.Is<Button>());
@@ -70,7 +70,7 @@ This is very similar to the [`OfType`](#ofType) selector except it also matches 
 
 > Again, the type of an object is actually determined by looking at its IStyleable.StyleKey property.
 
-## Child
+# Child
 
 ```xml
 <Style Selector="StackPanel > Button">
@@ -83,7 +83,7 @@ A child selector is defined by separating two selectors with a `>` character. Th
 _direct children in the logical tree_, so in the example above the selector will match any `Button`
 that is a direct logical child of a `StackPanel`.
 
-## Descendant
+# Descendant
 
 ```xml
 <Style Selector="StackPanel Button">
@@ -96,7 +96,7 @@ When two selectors are separated by a space, then the selector will match descen
 logical tree, so in this case the selector will match any `Button` that is a logical descendant
 of a `StackPanel`.
 
-## PropertyEquals
+# PropertyEquals
 
 ```xml
 <Style Selector="Button[IsDefault=true]">
@@ -107,7 +107,7 @@ new Style(x => x.OfType<Button>().PropertyEquals(Button.IsDefaultProperty, true)
 
 Matches any control which has the specified property set to the specified value.
 
-## Template
+# Template
 
 ```xml
 <Style Selector="Button /template/ ContentPresenter">

--- a/wwwroot/docs/styles/styles.md
+++ b/wwwroot/docs/styles/styles.md
@@ -35,7 +35,7 @@ Styles can be defined on any control or on the `Application` object by adding th
 
 A style applies to the control that it is defined on and all descendent controls.
 
-## Style Classes
+# Style Classes
 
 As in CSS, controls can be given *style classes* which can be used in selectors. Style classes
 can be assigned in XAML by setting the `Classes` property to a space-separated list of strings.
@@ -52,7 +52,7 @@ control.Classes.Add("blue");
 control.Classes.Remove("red");
 ```
 
-## Pseudoclasses
+# Pseudoclasses
 
 Also as in CSS, controls can have pseudoclasses; these are classes that are
 defined by the control itself rather than by the user. Pseudoclasses start
@@ -78,7 +78,7 @@ Pseudoclasses provide the functionality of `Triggers` in WPF and
 Other pseudoclasses include `:focus`, `:disabled`, `:pressed` for buttons,
 `:checked` for checkboxes etc.
 
-## Selectors
+# Selectors
 
 _Selectors_ select a control using a custom selector syntax which is very similar to the syntax
 used for CSS selectors. An example of some selectors:
@@ -96,7 +96,7 @@ used for CSS selectors. An example of some selectors:
 
 For more information see the  [selectors documentation](/docs/styles/selectors).
 
-## Setters
+# Setters
 
 A style's setters describe what will happen when the selector matches a control. They are simple
 property/value pairs written in the format:
@@ -110,7 +110,7 @@ Whenever a style is matched with a control, all of the setters will be applied t
 If a style selector should no longer match a control, the property value will revert to its
 previous value.
 
-## Style Precedence
+# Style Precedence
 
 If multiple styles match a control, and they both attempt to set the same property then the style
 _closest to the control_ will win. Consider the following example:

--- a/wwwroot/docs/templates/datatemplate.md
+++ b/wwwroot/docs/templates/datatemplate.md
@@ -179,7 +179,7 @@ in the `MainWindowViewModel.Content` property, the appropriate view will be disp
 <Window>
 ```
 
-## Evaluation Order
+# Evaluation Order
 
 Data templates in Avalonia can target interfaces and derived classes and so the order of
 DataTemplates can be important: DataTemplates within the same collection are evaluated in


### PR DESCRIPTION
Added disclaimer for the animations features.
Fix all headers so that they are addressable via the right sidebar of the website. 
Also fix the Style `Is` selector syntax.