### PR TITLE
Upgrade To Wyam 2.1.1 and API docs to 0.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 output
-output.zip
-packages.xml
 config.wyam.dll
 config.wyam.hash
-wyam
+config.wyam.packages.xml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://dev.azure.com/AvaloniaUI/avaloniaui.net/_apis/build/status/avaloniaui.net)](https://dev.azure.com/AvaloniaUI/avaloniaui.net/_build/latest?definitionId=1)
 
 # Manual Build Instructions
-Download and unpack `https://github.com/Wyamio/Wyam/releases/download/v1.0.0/Wyam-v1.0.0.zip` to `wyam` directory. Run `build.cmd`. The resulting website will be in the `output/` folder.
+
+Install the `Wyam.Tool` .NET Core Global Tool via `dotnet tool install -g Wyam.Tool`. Use the command `wyam -i wwwroot` to build the website. 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,16 +2,9 @@ queue:
   name: Hosted VS2017
 
 steps:
-- powershell: 'wget https://github.com/Wyamio/Wyam/releases/download/v1.0.0/Wyam-v1.0.0.zip -OutFile $(Build.SourcesDirectory)/Wyam-v1.0.0.zip'
-  displayName: 'Download Wyam'
+- script: 'dotnet install -g Wyam.Tool'
 
-- task: ExtractFiles@1
-  displayName: 'Extract files '
-  inputs:
-    archiveFilePatterns: '$(Build.SourcesDirectory)/Wyam-v1.0.0.zip'
-    destinationFolder: wyam
-
-- script: 'wyam\wyam.exe -i wwwroot'
+- script: 'wyam -i wwwroot'
   failOnStderr: true
   displayName: 'Generate website with Wyam'
   env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ queue:
   name: Hosted VS2017
 
 steps:
-- script: 'dotnet install -g Wyam.Tool'
+- script: 'dotnet tool install -g Wyam.Tool'
 
 - script: 'wyam -i wwwroot'
   failOnStderr: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,12 @@ queue:
   name: Hosted VS2017
 
 steps:
-- script: 'dotnet tool install -g Wyam.Tool'
+- task: DotNetCoreInstaller@0
+  inputs:
+    packageType: 'sdk'
+    version: '2.2.100' 
+
+- script: 'dotnet tool install -g Wyam.Tool --version 2.1.1'
 
 - script: 'wyam -i wwwroot'
   failOnStderr: true

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
 set SKIP_WYAM_API_GEN=0
-wyam\wyam.exe -i wwwroot
+wyam -i wwwroot
 pause

--- a/fast-buld-without-api.cmd
+++ b/fast-buld-without-api.cmd
@@ -1,3 +1,3 @@
 set SKIP_WYAM_API_GEN=1
-wyam\wyam.exe -i wwwroot
+wyam -i wwwroot
 pause

--- a/serve.cmd
+++ b/serve.cmd
@@ -1,1 +1,1 @@
-wyam\wyam.exe preview
+wyam preview

--- a/wwwroot/_NavBar.cshtml
+++ b/wwwroot/_NavBar.cshtml
@@ -1,5 +1,5 @@
 @{
-    List<Tuple<string, string>> pages = new List<Tuple<string, string>>
+    List<Tuple<string, string>> topLevelPages = new List<Tuple<string, string>>
     {
         Tuple.Create("Blog", Context.GetLink("blog")),
         Tuple.Create("Documentation", Context.GetLink("docs")),
@@ -7,9 +7,9 @@
         Tuple.Create("API", Context.GetLink("api")),
         Tuple.Create("<i class=\"fa fa-github\"></i> Source", "https://github.com/AvaloniaUI/Avalonia")
     };
-    foreach(Tuple<string, string> page in pages)
+    foreach(Tuple<string, string> topLevelPage in topLevelPages)
     {
-        string active = Context.GetLink(Document).StartsWith(page.Item2) ? "active" : null;
-        <li class="@active"><a href="@page.Item2">@Html.Raw(page.Item1)</a></li>
+        string active = Context.GetLink(Document).StartsWith(topLevelPage.Item2) ? "active" : null;
+        <li class="@active"><a href="@topLevelPage.Item2">@Html.Raw(topLevelPage.Item1)</a></li>
     }
 }


### PR DESCRIPTION
We've been using Wyam 1.0. We should upgrade to the newest version which is deployed via a .NET Core Tool.

Additionally, I noticed that our source for the API docs gen wasn't updated to 0.7.0, so I updated that as well.