### PR TITLE
Fix broken link to 'create new project' in datacontext.md

### DIFF
--- a/wwwroot/docs/binding/datacontext.md
+++ b/wwwroot/docs/binding/datacontext.md
@@ -9,7 +9,7 @@ and child controls will inherit this data context.
 
 When using the MVVM pattern, the data context will usually be an instance of a view model.
 
-If you created your application with the [Avalonia MVVM Application](create-new-project.md) template
+If you created your application with the [Avalonia MVVM Application](/docs/quickstart/create-new-project) template
 then you will see something like this in your `Program.cs` file:
 
 ```csharp


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes a broken link to the 'create new project' in datacontext.md



**What is the current behavior?**
points to a non-existent page at http://avaloniaui.net/docs/binding/create-new-project.md



**What is the new behavior?**
Points to the actual page at http://avaloniaui.net/docs/quickstart/create-new-project


