### PR TITLE
Update build.md with more specific Linux/macOS instructions

### DIFF
--- a/wwwroot/contributing/build.md
+++ b/wwwroot/contributing/build.md
@@ -17,9 +17,9 @@ git submodule update --init
 Open the `Avalonia.sln` solution in Visual Studio 2017 or newer. The free Visual Studio Community
 edition works fine. Run the `Samples\ControlCatalog.Desktop` project to see the sample application.
 
-# Linux/OSX
+# Linux/macOS
 
-It's *not* possible to build the *whole* project on Linux/OSX. You can only build the subset targeting .NET Standard and .NET Core (which is, however, sufficient to get UI working on Linux/OSX). If you want to something that involves changing platform-specific APIs you'll need a Windows machine.
+It's *not* possible to build the *whole* project on Linux/macOS. You can only build the subset targeting .NET Standard and .NET Core (which is, however, sufficient to get UI working on Linux/macOS). If you want to something that involves changing platform-specific APIs you'll need a Windows machine.
 
 MonoDevelop, Xamarin Studio and Visual Studio for Mac aren't capable of properly opening our solution. You can use Rider (at least 2017.2 EAP) or VSCode instead. They will fail to load most of platform specific projects, but you don't need them to run on .NET Core.
 
@@ -27,17 +27,56 @@ MonoDevelop, Xamarin Studio and Visual Studio for Mac aren't capable of properly
 
 Go to https://www.microsoft.com/net/core and follow instructions for your OS. You need SDK (not just "runtime") package.
 
+###  Additional requirements for macOS
+
+The build process needs [Xcode](https://developer.apple.com/xcode/) to build the native library.  Following the install instructions at the [Xcode](https://developer.apple.com/xcode/) website to properly install.
+
+Linux operating systems ship with their own respective package managers however we will use [Homebrew](https://brew.sh/) to manage packages on macOS.  To install follow the instructions [here](https://docs.brew.sh/Installation).
+
+###  Install CastXML
+
+Avalonia requires [CastXML](https://github.com/CastXML/CastXML) for XML processing during the build process.  The easiest way to install this is via the operating system's package managers, such as below.
+
+On macOS:
+```
+brew install castxml
+```
+
+On Debian based Linux (Debian, Ubuntu, Mint, etc):
+```
+sudo apt install castxml
+```
+
+On Red Hat based Linux (Fedora, CentOS, RHEL, etc) using `yum` (`dnf` takes same arguments though):
+```
+sudo yum install castxml
+```
+
+
 ###  Clone the Avalonia repository
 
 ```
 git clone https://github.com/AvaloniaUI/Avalonia.git
+cd Avalonia
 git submodule update --init --recursive
+```
+
+### Build native libraries (macOS only)
+
+On macOS it is necessary to build and manually install the respective native libraries using [Xcode](https://developer.apple.com/xcode/).  The steps to get this working correctly are:
+- Navigate to the Avalonia/native/Avalonia.Native/src/OSX folder and open the `Avalonia.Native.OSX.xcodeproj` project
+- Build the library via the Product->Build menu.  This will generate binaries in your local path under ~/Library/Developer/Xcode/DerivedData/Avalonia.Native.OSX-*guid* where "guid" is uniquely generated every time you build.
+- Manually install the native library by copying it from the build artifacts folder into the shared dynamic library path:
+
+```
+cd ~/Library/Developer/Xcode/DerivedData/Avalonia.Native.OSX-[guid]/Build/Products/Debug
+cp libAvalonia.Native.OSX.dylib /usr/local/lib/libAvaloniaNative.dylib
 ```
 
 ###  Build and Run Avalonia
 
 ```
-samples/ControlCatalog.NetCore
+cd samples/ControlCatalog.NetCore
 dotnet restore
 dotnet run
 ```


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Adds additional instructions for building Avalonia source on Linux and macOS



**What is the current behavior?**
Leaves out details about dependency tools and libraries



**What is the new behavior?**
Fully describes the dependencies and additional build steps which previously required foreknowledge or discussions with developers on Gitter.


