### PR TITLE
Change avalonia.app.mvvm to avalonia.mvvm

### DIFF
--- a/wwwroot/docs/quickstart/create-new-project.md
+++ b/wwwroot/docs/quickstart/create-new-project.md
@@ -26,7 +26,7 @@ First install the Avalonia templates for .NET Core by following the instructions
 This will add a couple of project templates to `dotnet`:
 
 - **`avalonia.app`**: This will create a barebones Avalonia application
-- **`avalonia.app.mvvm`**: This will create an application that uses the Model-View-ViewModel pattern with [ReactiveUI](https://reactiveui.net/)
+- **`avalonia.mvvm`**: This will create an application that uses the Model-View-ViewModel pattern with [ReactiveUI](https://reactiveui.net/)
 
 To create a project using the templates use `dotnet new`:
 


### PR DESCRIPTION
As far as I can tell `avalonia.app.mvvm` has never been the short name for the template?