### PR TITLE
Remove outdated note

### DIFF
--- a/wwwroot/docs/styles/resources.md
+++ b/wwwroot/docs/styles/resources.md
@@ -76,11 +76,6 @@ respect to `DynamicResource`:
 In return, `StaticResource` doesn't need to add an event handler to listen for changes in resources
 which means it uses slightly less memory.
 
-:::note
-In WPF and UWP `StaticResource` can reference a resource in `App.xaml`. This is not the case in
-Avalonia because a window can opt-out of `Application` resources and styles.
-:::
-
 # Overriding resources
 
 Resources are resolved by walking up the logical tree from the point of the `DynamicResource` or


### PR DESCRIPTION
I tested it and StaticResource successfully finds the resource placed in App.xaml (Application.Resources) - is this note outdated or am I wrong?
I don't know why GitHub sees last line as a change - nothing changed there.