### PR TITLE
Fixed typo in wiring-up-views.md

### DIFF
--- a/wwwroot/docs/tutorial/wiring-up-views.md
+++ b/wwwroot/docs/tutorial/wiring-up-views.md
@@ -33,7 +33,7 @@ Content="{Binding List}"
 ```
 
 `{Binding}` is a markup extension which instantiates a [binding](/docs/binding/bindings) to a 
-property on a control's `DataContext`. You'll remember that in `Program.cs` we [assigned an
+property on a control's `DataContext`. You'll remember that in `App.xaml.cs` we [assigned an
 instance of `MainWindowViewModel` to the window's `DataContext` property](/docs/tutorial/creating-model-viewmodel#creating-an-instance-of-todolistviewmodel).
 
 :::note


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Changes "Program.cs" to "App.xaml.cs" in wiring-up-views.md


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
Incorrectly states that "You'll remember that in **Program.cs** we assigned an instance of MainWindowViewModel to the window's DataContext property."


**What is the new behavior?**
<!-- Describe what's changed. -->
Changed to "You'll remember that in **App.xaml.cs** we assigned an instance of MainWindowViewModel to the window's DataContext property."

