### PR TITLE
#119 Fixed broken images due to wrong file extension

### DIFF
--- a/wwwroot/docs/layout/alignment-margins-padding.md
+++ b/wwwroot/docs/layout/alignment-margins-padding.md
@@ -10,7 +10,7 @@ There are numerous ways to position elements using Avalonia. However, achieving 
 
 The following illustration shows a layout scenario that utilizes several positioning properties.
 
-![Positioning Example](images/layout-margins-padding-alignment-graphic1.PNG)
+![Positioning Example](images/layout-margins-padding-alignment-graphic1.png)
 
 At first glance, the `Button` elements in this illustration may appear to be placed randomly. However, their positions are actually precisely controlled by using a combination of margins, alignments, and padding.
 
@@ -44,7 +44,7 @@ The following example describes how to create the layout in the preceding illust
 
 The following diagram provides a close-up view of the various positioning properties that are used in the preceding sample. Subsequent sections in this topic describe in greater detail how to use each positioning property.
 
- ![Positioning Properties](images/layout-margins-padding-alignment-graphic2.PNG)
+ ![Positioning Properties](images/layout-margins-padding-alignment-graphic2.png)
 
 # Understanding Alignment Properties
 
@@ -76,7 +76,7 @@ The following example shows how to apply the `HorizontalAlignment` property to `
 
 The preceding code yields a layout similar to the following image. The positioning effects of each `HorizontalAlignment` value are visible in the illustration.
 
-![HorizontalAlignment Sample](images/layout-horizontal-alignment-graphic.PNG)
+![HorizontalAlignment Sample](images/layout-horizontal-alignment-graphic.png)
 
 ## VerticalAlignment Property
 
@@ -116,7 +116,7 @@ The following example shows how to apply the `VerticalAlignment` property to `Bu
 
 The preceding code yields a layout similar to the following image. The positioning effects of each `VerticalAlignment` value are visible in the illustration.
 
-![VerticalAlignment property sample](images/layout-vertical-alignment-graphic.PNG)
+![VerticalAlignment property sample](images/layout-vertical-alignment-graphic.png)
 
 # Understanding Margin Properties
 
@@ -226,4 +226,4 @@ The following example demonstrates each of the concepts that are detailed in thi
 
 When compiled, the preceding application yields a UI that looks like the following illustration. The effects of the various property values are evident in the spacing between elements, and significant property values for elements in each column are shown within `TextBlock` elements.
 
-![Several positioning properties in one application](images/layout-margins-padding-aligment-graphic3.PNG)
+![Several positioning properties in one application](images/layout-margins-padding-aligment-graphic3.png)


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixed broken images due to wrong file extension .PNG in uppercase while they should be lowercase



**What is the current behavior?**
Images do not render in the browser



**What is the new behavior?**
Images can render in the browser


