### PR TITLE
#124: Fix link labels and titles for ComboBox and Viewbox

### DIFF
--- a/wwwroot/docs/controls/combobox.md
+++ b/wwwroot/docs/controls/combobox.md
@@ -1,9 +1,8 @@
 Title: ComboBox
 ---
+A drop-down list control.
 
- A drop-down list control.
-
- # Common Properties
+# Common Properties
 
 |Property|Description|
 |--------|-----------|
@@ -15,14 +14,14 @@ Title: ComboBox
 |`IsDropDownOpen`|Gets or sets a value indicating whether the dropdown is currently open.|
 |`MaxDropDownHeight`|Gets or sets the maximum height for the dropdown list.|
 
- # Source code
+# Source code
 [ComboBox.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/ComboBox.cs)
 
 # Examples
 
- ## Basic ComboBox
- ```xml
- <Window xmlns="https://github.com/avaloniaui"
+## Basic ComboBox
+```xml
+<Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -38,11 +37,11 @@ Title: ComboBox
         </ComboBox>
     </StackPanel>
 </Window>
- ```
+```
 
-  ## ComboBox with custom item templates
- ```xml
- <Window xmlns="https://github.com/avaloniaui"
+## ComboBox with custom item templates
+```xml
+<Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -66,14 +65,14 @@ Title: ComboBox
       </ComboBox>
     </StackPanel>
 </Window>
- ```
+```
 
- ## ComboBox with binding
+## ComboBox with binding
 
 This example binds the fonts installed to a ComboBox
 
- ```xml
- <Window xmlns="https://github.com/avaloniaui"
+```xml
+<Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -90,12 +89,12 @@ This example binds the fonts installed to a ComboBox
        </ComboBox>
     </StackPanel>
 </Window>
- ```
+```
 
- With this code behind:
+With this code behind:
 
- ```cs
+```cs
 var fontComboBox = this.Find<ComboBox>("fontComboBox");
 fontComboBox.Items = FontManager.Current.GetInstalledFontFamilyNames().Select(x => new FontFamily(x));
 fontComboBox.SelectedIndex = 0;
- ```
+```

--- a/wwwroot/docs/controls/viewbox.md
+++ b/wwwroot/docs/controls/viewbox.md
@@ -1,6 +1,6 @@
-Title: Expander
+Title: Viewbox
 ---
 `Viewbox` is used to scale single child.
 
 # Source code
-[Expander.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/ViewBox.cs)
+[Viewbox.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Viewbox.cs)


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Clear and concise description of this PR. -->

Fixes an incorrect page title used for `Viewbox` and fixes the links found in `ComboBox` and `Viewbox`. Closes #124.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

See #124.

**What is the new behavior?**
<!-- Describe what's changed. -->

- The duplicate `Expander` entry in the sidebar is fixed, and now shows `Viewbox` instead
- Source code link for `Viewbox.cs` has been corrected
- Labels for the source code links to `ComboBox.cs` and `Viewbox.cs` have been fixed

I've tried to match the formatting seen in other `.md` files, so there's also some whitespace changes in `combobox.md`.