### PR TITLE
Fix PR NuGet feed URL

### DIFF
--- a/wwwroot/docs/quickstart/packages.md
+++ b/wwwroot/docs/quickstart/packages.md
@@ -35,7 +35,7 @@ And then in the NuGet package manager, select the `AvaloniaCI` package source.
 
 ## PR Feed
 
-Pull request build results are published to a [separate feed](https://www.myget.org/F/valonia-prs/api/v3/index.json).
+Pull request build results are published to a [separate feed](https://www.myget.org/F/avalonia-prs/api/v3/index.json).
 
 To get the version for a particular pull request you need to check the build number from the PR build on Azure Pipelines. Then you can use this build to determine the PR package version.
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes URL for PR NuGet feed

**What is the current behavior?**
The link doesn't go to the right place.

**What is the new behavior?**
Fixed URL so people can find the PR feed.


