### PR TITLE
Hero styles modified solution to #139

### DIFF
--- a/src/AvaloniaUI.Net/wwwroot/css/hero.css
+++ b/src/AvaloniaUI.Net/wwwroot/css/hero.css
@@ -1,13 +1,13 @@
 /* Default sidebar leaves space for hamburger menu bar, but hero sidebar doesn't */
 .hero-container .sidebar {
-    margin-top: 0;
+  margin-top: 0;
 }
 
-  /* Default sidebar hides logo on narrow layouts, but hero sidebar doesn't */
-  .hero-container .sidebar .avalonia-logo {
-    display: inline-block;
-    margin: -14px 0 var(--padding-small) 2px;
-  }
+/* Default sidebar hides logo on narrow layouts, but hero sidebar doesn't */
+.hero-container .sidebar .avalonia-logo {
+  display: inline-block;
+  margin: -14px 0 var(--padding-small) 2px;
+}
 
 
 .hero-content {
@@ -18,11 +18,35 @@
   padding: var(--padding-large);
 }
 
-  .hero-content .center {
-    justify-content: center;
-    flex-direction: column;
-    display: flex;
-    height: 100%;
+.hero-content .center {
+  justify-content: center;
+  flex-direction: column;
+  display: flex;
+  height: 100%;
+}
+
+.hero-content .two-column {
+  display: grid;
+  grid-template-columns: 1fr;
+  align-items: center;
+  justify-items: center;
+  height: 100%;
+}
+
+.hero-content .two-column > * {
+  padding: var(--padding-small);
+}
+
+/* Display hero section in 2 columns if > 1024px */
+
+@media (min-width: 1025px) {
+  .hero-container {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+  }
+
+  .hero-content {
+    padding-top: var(--nav-height);
   }
 
   .hero-content .two-column {
@@ -31,21 +55,5 @@
     align-items: center;
     justify-items: center;
     height: 100%;
-  }
-
-    .hero-content .two-column > * {
-      padding: var(--padding-large);
-    }
-
-/* Display hero section in 2 columns if > 1024px */
-
-@media (min-width: 1024px) {
-  .hero-container {
-    display: grid;
-    grid-template-columns: 1fr 2fr;
-  }
-
-  .hero-content {
-    padding-top: var(--nav-height);
   }
 }


### PR DESCRIPTION
The hero styles were slightly modified to adapt better to medium and small screens .

**What kind of change does this PR introduce?**
Modifications to hero.css, padding was reduced and classes inside media queries were created. 



**What is the current behavior?**
Columns on the hero section look narrow in small screens. As reported in #139. This happens in contributing and support pages.



**What is the new behavior?**
Hero columns are more legible and responsive. This happens in contributing and support pages.


