### PR TITLE
Move some tags to prevent missing tag error in IDE and allow formatting

### DIFF
--- a/src/AvaloniaUI.Net/Pages/Shared/_DocsLayout.cshtml
+++ b/src/AvaloniaUI.Net/Pages/Shared/_DocsLayout.cshtml
@@ -1,4 +1,6 @@
 @* Layout for docs and blogs *@
+<!DOCTYPE html>
+<html lang="en">
 <partial name="_Head.cshtml"/>
 
 <body>

--- a/src/AvaloniaUI.Net/Pages/Shared/_Head.cshtml
+++ b/src/AvaloniaUI.Net/Pages/Shared/_Head.cshtml
@@ -1,6 +1,3 @@
-<!DOCTYPE html>
-<html lang="en">
-
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/AvaloniaUI.Net/Pages/Shared/_Layout.cshtml
+++ b/src/AvaloniaUI.Net/Pages/Shared/_Layout.cshtml
@@ -1,5 +1,6 @@
 @* Layout for pages with a hero section, such as index and support *@
-
+<!DOCTYPE html>
+<html lang="en">
 <partial name="_Head.cshtml" />
 
 <body>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Moves the doctype and html opening tags to the respective layouts, this prevents errors/warnings from showing and help with the indentation because the file is properly formatted.
Also, semantically the head partial now only contains the head tag.


**What is the current behavior?**
IDE can't properly indent and an error of no matching opening tag is shown



**What is the new behavior?**
IDE does not show the error, formatting works properly on those files


