### PR TITLE
Fixes combobox title showing as undefined

### DIFF
--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/combobox.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/combobox.md
@@ -1,3 +1,4 @@
+---
 Title: ComboBox
 ---
 A drop-down list control.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes opening in markdown parameters



**What is the current behavior?**
http://avaloniaui.net/docs/controls/combobox shows its title as Undefined


**What is the new behavior?**
The title correctly shows as ComboBox


