### PR TITLE
Allows to sort folder contents by name on the treeview

### DIFF
--- a/src/AvaloniaUI.Net/Pages/Docs/Index.cshtml.cs
+++ b/src/AvaloniaUI.Net/Pages/Docs/Index.cshtml.cs
@@ -28,6 +28,9 @@ namespace AvaloniaUI.Net.Pages.Docs
         public DocsArticle? Article { get; private set; }
         public List<DocsIndexItem>? Index { get; private set; }
         public List<DocsIndexItem>? SectionIndex { get; private set; }
+        
+        //Provide here the list of folders which contents will be sorted by name on the TreeView
+        private List<string> NameSortedFolders  { get; } = new List<string> {"controls"};
 
         public async Task<IActionResult> OnGet(string url)
         {
@@ -121,7 +124,17 @@ namespace AvaloniaUI.Net.Pages.Docs
                 }
             }
 
-            result.Sort((x, y) => x.Order - y.Order);
+            if (NameSortedFolders.Contains(Path.GetFileName(path)))
+            {
+                //Sorting by Name
+                result.Sort((x, y) => string.CompareOrdinal(x.Title, y.Title));
+            }
+            else
+            {
+                //Sorting by Order
+                result.Sort((x, y) => x.Order - y.Order);
+            }
+            
             return result;
         }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Introduces the ability to set folder names on a list which contents will be displayed in alphabetical order on the sidebar treeview. Some folders like the controls should be sorted by name. This approach could be expanded upon or could be replaced by adding the order information manually.



**What is the current behavior?**
Folders and items that do not contain order information are not sorted. Controls' folder contents are sorted randomly.



**What is the new behavior?**
At the moment the controls' folder contents are shown in alphabetical order.
