### PR TITLE
Fix #157: rewind a stream reader after reading a YAML preamble

### DIFF
--- a/src/AvaloniaUI.Net/Services/MarkdownDocumentLoader.cs
+++ b/src/AvaloniaUI.Net/Services/MarkdownDocumentLoader.cs
@@ -56,11 +56,31 @@ namespace AvaloniaUI.Net.Services
             parser.Consume<StreamStart>();
             parser.Consume<DocumentStart>();
 
-            return (TFrontMatter?)deserializer.DeserializeValue(
+            var result = (TFrontMatter?)deserializer.DeserializeValue(
                 parser,
                 typeof(TFrontMatter),
                 new SerializerState(),
                 deserializer);
+
+            // Currently, the parser has read all the document and stays at the last token of it (*before* closing `---`
+            // line). At the same time, it has already peeked the first character of the next line *after* the end of
+            // the document from the StreamReader instance.
+            //
+            // So, we have to rewind the stream. To do that, calculate position of the next document start token, and
+            // rewind the basic stream and the stream reader itself.
+            _ = parser.Consume<DocumentEnd>();
+            var nextDocumentStart = (DocumentStart)parser.Current!;
+            var position = nextDocumentStart.End.Index // points *before* the closing `---`
+                           + 1; // points to the first character of closing `---`
+            RewindReaderTo(r, position);
+            _ = r.ReadLine(); // should be `---`
+            return result;
+
+            static void RewindReaderTo(StreamReader r, int position)
+            {
+                r.BaseStream.Position = position;
+                r.DiscardBufferedData();
+            }
         }
     }
 }


### PR DESCRIPTION
- Closes #153.
- Closes #157.

Please see the comments in the code for the explanation of the current behavior and of my fix.

I should say that the current parser behavior isn't 100% clear to me (why does it say that the document starts *before* `---`? who knows), but I've verified that all the blog posts (both the ones that had troubles and the ones that had no beforehand) render correctly after this fix.

Probably we could migrate away from YAML if we only use it for simple key-value reading, because this is quickly getting out of hand.