### PR TITLE
Adding meta description tag

### DIFF
--- a/src/AvaloniaUI.Net/Pages/Shared/_Head.cshtml
+++ b/src/AvaloniaUI.Net/Pages/Shared/_Head.cshtml
@@ -1,7 +1,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <environment include="Development">
+  <meta name="description" content="A cross platform XAML-based UI framework for .NET Core, .NET Framework and Mono. Avalonia supports Windows, Linux and macOS with experimental mobile support.">
+   <environment include="Development">
     <link rel="stylesheet" href="~/css/normalize.css">
     <link rel="stylesheet" href="~/css/vars.css">
     <link rel="stylesheet" href="~/css/base.css">


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Adds a meta description for SEO and to be used by Search Engines.



**What is the current behavior?**
There is no tag and the current description in google is the following
![2020-07-10 20_21_43-avalonia ui - Buscar con Google](https://user-images.githubusercontent.com/1598555/87213489-0712d800-c2eb-11ea-98d1-3ffe4b70a780.png)




**What is the new behavior?**
There is a description within the recommended length that will eventually show up in Google. The description was crafted between the one used in the site and the one used in the Github project page.


