### PR TITLE
Secure external links

### DIFF
--- a/src/AvaloniaUI.Net/Pages/Shared/_Navbar.cshtml
+++ b/src/AvaloniaUI.Net/Pages/Shared/_Navbar.cshtml
@@ -15,8 +15,8 @@
       <li class="nav-item"><a href="/support">Support</a></li>
       <li class="nav-item"><a href="/docs">Documentation</a></li>
       <li class="nav-item"><a href="/contributing">Contributing</a></li>
-      <li class="nav-item"><a href="http://reference.avaloniaui.net/api" target="_blank">API</a></li>
-      <li class="nav-item"><a href="https://github.com/AvaloniaUI/Avalonia" target="_blank">Source</a></li>
+      <li class="nav-item"><a href="http://reference.avaloniaui.net/api" target="_blank" rel="noopener">API</a></li>
+      <li class="nav-item"><a href="https://github.com/AvaloniaUI/Avalonia" target="_blank" rel="noopener">Source</a></li>
     </ul>
   </nav>
 </header>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Adds an attribute to the links that open in a target="_blank" which seems to be unsafe as reported by lighthouse


**What is the current behavior?**
There is a regular link which triggers a warning in lighthouse.
![2020-07-11 11_24_29-DevTools - avaloniaui net_](https://user-images.githubusercontent.com/1598555/87228934-040afc80-c36a-11ea-9842-80bc98f53679.png)



**What is the new behavior?**
It was added the attribute rel="noopener" to a couple of links


