### PR TITLE
Add reference link to the doc page of all controls

### DIFF
--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/border.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/border.md
@@ -35,5 +35,8 @@ An example of a border with a red background, 2 pixel black border, 3 pixel corn
 
 None
 
+## Reference
+[Border](http://reference.avaloniaui.net/api/Avalonia.Controls/Border/)
+
 ## Source code
 [Border.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Border.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/button.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/button.md
@@ -34,6 +34,9 @@ The Button control's full documentation can be found [here](/api/Avalonia.Contro
 |-----------|-----------|
 |`:pressed`|Set when the button is depressed|
 
+## Reference
+[Button](http://reference.avaloniaui.net/api/Avalonia.Controls/Button/)
+
 ## Source code
 [Button.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Button.cs)
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/calendar.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/calendar.md
@@ -16,6 +16,9 @@ The `Calendar` control is a standard Calendar control for users to select date(s
 |`DisplayDateEnd`|Gets or sets the last date to be displayed.|
 |`BlackoutDates`|Gets a collection of dates that are marked as not selectable.|
 
+## Reference
+[Calendar](http://reference.avaloniaui.net/api/Avalonia.Controls/Calendar/)
+
 ## Source code
 [Calendar.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Calendar/Calendar.cs)
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/canvas.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/canvas.md
@@ -3,5 +3,8 @@ Title: Canvas
 ---
 The `Canvas` control is a `Panel` which lays out its children by explicit coordinates.
 
+## Reference
+[Canvas](http://reference.avaloniaui.net/api/Avalonia.Controls/Canvas/)
+
 ## Source code
 [Canvas.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Canvas.cs){target="_blank"}

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/carousel.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/carousel.md
@@ -3,5 +3,8 @@ Title: Carousel
 ---
 The `Carousel` control is an items control that displays its items as pages that fill the control.
 
+## Reference
+[Carousel](http://reference.avaloniaui.net/api/Avalonia.Controls/Carousel/)
+
 ## Source code
 [Carousel.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Carousel.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/checkbox.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/checkbox.md
@@ -10,6 +10,9 @@ The `CheckBox` control is a [`ContentControl`](contentcontrol) which allows user
 |`IsChecked`|Is `CheckBox` checked|
 |`IsThreeState`|Is `CheckBox` in three state mode|
 
+## Reference
+[Checkbox](http://reference.avaloniaui.net/api/Avalonia.Controls/Checkbox/)
+
 ## Source code
 
 [CheckBox.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/CheckBox.cs)  

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/combobox.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/combobox.md
@@ -15,6 +15,9 @@ A drop-down list control.
 |`IsDropDownOpen`|Gets or sets a value indicating whether the dropdown is currently open.|
 |`MaxDropDownHeight`|Gets or sets the maximum height for the dropdown list.|
 
+## Reference
+[ComboBox](http://reference.avaloniaui.net/api/Avalonia.Controls/ComboBox/)
+
 # Source code
 [ComboBox.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/ComboBox.cs)
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/contentcontrol.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/contentcontrol.md
@@ -10,6 +10,9 @@ The [`ContentControl`](/api/Avalonia.Controls/ContentControl) displays data acco
 |--------|-----------|
 |`Content`|The content to display in the control|
 
+## Reference
+[ContentControl](http://reference.avaloniaui.net/api/Avalonia.Controls/ContentControl/)
+
 ## Source code
 
 [ContentControl.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/ContentControl.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/contextmenu.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/contextmenu.md
@@ -3,5 +3,8 @@ Title: ContextMenu
 ---
 The `ContextMenu` control is a menu that can be applied to any control to provide right-click control-specfic menus.
 
+## Reference
+[ContextMenu](http://reference.avaloniaui.net/api/Avalonia.Controls/ContextMenu/)
+
 ## Source code
 [ContextMenu.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/ContextMenu.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/decorator.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/decorator.md
@@ -3,5 +3,8 @@ Title: Decorator
 ---
 The `Decorator` is the base decorator class for decorating a single child control.
 
+## Reference
+[Decorator](http://reference.avaloniaui.net/api/Avalonia.Controls/Decorator/)
+
 ## Source code
 [Decorator.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Decorator.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/dockpanel.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/dockpanel.md
@@ -3,5 +3,8 @@ Title: DockPanel
 ---
 The `DockPanel` control is a `Panel` which lays out its children by "docking" them to the sides or floating in the center.
 
+## Reference
+[DockPanel](http://reference.avaloniaui.net/api/Avalonia.Controls/DockPanel/)
+
 ## Source code
 [DockPanel.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/DockPanel.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/expander.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/expander.md
@@ -3,7 +3,8 @@ Title: Expander
 ---
 The `Expander` control is a control that allows for expanding to show nested content.
 
+## Reference
+[Expander](http://reference.avaloniaui.net/api/Avalonia.Controls/Expander/)
+
 ## Source code
 [Expander.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Expander.cs)
-
-

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/grid.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/grid.md
@@ -4,6 +4,9 @@ Title: Grid
 The `Grid` control is a `Panel` control useful for organizing other controls in columns and rows. `ColumnDefinition` and `RowDefinition` properties are used to define absolute, relative, or proportional row and column geometries for the grid.
 Each control in the grid will be placed using the `Grid.Column` and `Grid.Row` additional properties. It is also possible to have controls that span multiple rows and/or columns by using the `ColumnSpan` and `RowSpan` properties.
 
+## Reference
+[Grid](http://reference.avaloniaui.net/api/Avalonia.Controls/Grid/)
+
 ## Source code
 [Grid.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Grid.cs)
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/gridsplitter.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/gridsplitter.md
@@ -3,5 +3,8 @@ Title: GridSplitter
 ---
 The `GridSplitter` control is a control that allows a user to resize the space between `Grid` rows or columns
 
+## Reference
+[GridSplitter](http://reference.avaloniaui.net/api/Avalonia.Controls/GridSplitter/)
+
 ## Source code
 [GridSplitter.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/GridSplitter.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/image.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/image.md
@@ -3,5 +3,8 @@ Title: Image
 ---
 The `Image` control is a control for displaying raster images.
 
+## Reference
+[Image](http://reference.avaloniaui.net/api/Avalonia.Controls/Image/)
+
 ## Source code
 [Image.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Image.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/itemscontrol.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/itemscontrol.md
@@ -3,5 +3,8 @@ Title: ItemsControl
 ---
 The `ItemsControl` control is the base class for controls that display multiple items like `ListBox`.
 
+## Reference
+[ItemsControl](http://reference.avaloniaui.net/api/Avalonia.Controls/ItemsControl/)
+
 ## Source code
 [ItemsControl.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/ItemsControl.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/itemsrepeater.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/itemsrepeater.md
@@ -11,6 +11,9 @@ https://docs.microsoft.com/en-us/uwp/api/microsoft.ui.xaml.controls.itemsrepeate
 
 The only difference between the two controls is that in Avalonia the `ItemsSource` is called `Items`.
 
+## Reference
+[ItemsRepeater](http://reference.avaloniaui.net/api/Avalonia.Controls/ItemsRepeater/)
+
 ## Source code
 [ItemsRepeater.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Repeater/ItemsRepeater.cs)
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/layouttransformcontrol.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/layouttransformcontrol.md
@@ -3,5 +3,8 @@ Title: LayoutTransformControl
 ---
 The `LayoutTransformControl` allows for dynamically transforming layout completely within the View class definition.
 
+## Reference
+[LayoutTransformControl](http://reference.avaloniaui.net/api/Avalonia.Controls/LayoutTransformControl/)
+
 ## Source code
 [LayoutTransformControl.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/LayoutTransformControl.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/listbox.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/listbox.md
@@ -47,5 +47,8 @@ if you want wrapping text in the items) you can disable the horizontal scrollbar
 
 ```
 
+## Reference
+[ListBox](http://reference.avaloniaui.net/api/Avalonia.Controls/ListBox/)
+
 ## Source code
 [ListBox.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/ListBox.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/menu.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/menu.md
@@ -208,6 +208,8 @@ Finally assign the bindings to the view model in a `Style` within the menu:
 </Menu>
 ```
 
+## Reference
+[Menu](http://reference.avaloniaui.net/api/Avalonia.Controls/Menu/)
+
 ## Source code
 [Menu.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Menu.cs)
-

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/nativemenu.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/nativemenu.md
@@ -3,7 +3,8 @@ Title: NativeMenu
 ---
 Displays a native menu on OSX.
 
+## Reference
+[NativeMenu](http://reference.avaloniaui.net/api/Avalonia.Controls/NativeMenu/)
+
 ## Source code
 [NativeMenu.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/NativeMenu.cs)
-
-

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/numericupdown.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/numericupdown.md
@@ -5,11 +5,11 @@ The `NumericUpDown` is an editable numeric input field.
 The control has a up and down button spinner attached, used to increment and decrement the value in the input field. 
 The value can also be incremented or decremented using the arrow keys or the mouse wheel when the control is selected.
 
+## Reference
+[NumericUpDown](http://reference.avaloniaui.net/api/Avalonia.Controls/NumericUpDown/)
+
 ## Source code
 [NumericUpDown.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs)
-
-## API
-[NumericUpDown API](http://reference.avaloniaui.net/api/Avalonia.Controls/NumericUpDown/)
 
 # Examples
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/panel.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/panel.md
@@ -3,5 +3,8 @@ Title: Panel
 ---
 The `Panel` is the base class for controls that can contain multiple children like `DockPanel` or `StackPanel`.
 
+## Reference
+[Panel](http://reference.avaloniaui.net/api/Avalonia.Controls/Panel/)
+
 ## Source code
 [Panel.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Panel.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/progressbar.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/progressbar.md
@@ -3,5 +3,8 @@ Title: ProgressBar
 ---
 The `ProgressBar` control allow for showing dynamic progress status.
 
+## Reference
+[ProgressBar](http://reference.avaloniaui.net/api/Avalonia.Controls/ProgressBar/)
+
 ## Source code
 [ProgressBar.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/ProgressBar.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/radiobutton.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/radiobutton.md
@@ -3,5 +3,8 @@ Title: RadioButton
 ---
 The `RadioButton` control allows users to select one or more things from a collection of presented things.
 
+## Reference
+[RadioButton](http://reference.avaloniaui.net/api/Avalonia.Controls/RadioButton/)
+
 ## Source code
 [RadioButton.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/RadioButton.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/repeatbutton.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/repeatbutton.md
@@ -4,6 +4,8 @@ Title: RepeatButton
 
 The `RepeatButton` is a `Button` control that has the added feature of regularly generating [`Click`](/api/Avalonia.Controls/Button/61B1E7A8) events while the button is being pressed down.
 
+## Reference
+[RepeatButton](http://reference.avaloniaui.net/api/Avalonia.Controls/RepeatButton/)
 
 ## Source code
 [RepeatButton.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/RepeatButton.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/scrollbar.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/scrollbar.md
@@ -3,7 +3,8 @@ Title: ScrollBar
 ---
 A scrollbar control
 
+## Reference
+[ScrollBar](http://reference.avaloniaui.net/api/Avalonia.Controls/ScrollBar/)
+
 ## Source code
 [ScrollBar.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Primitives/ScrollBar.cs)
-
-

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/scrollviewer.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/scrollviewer.md
@@ -3,5 +3,8 @@ Title: ScrollViewer
 ---
 The `ScrollViewer` control scrolls its content if the content is bigger than the space available.
 
+## Reference
+[ScrollViewer](http://reference.avaloniaui.net/api/Avalonia.Controls/ScrollViewer/)
+
 ## Source code
 [ScrollViewer.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/ScrollViewer.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/separator.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/separator.md
@@ -4,5 +4,8 @@ Title: Separator
 
 The `Separator` control is used to provide visual separators within a `Menu` control.
 
+## Reference
+[Separator](http://reference.avaloniaui.net/api/Avalonia.Controls/Separator/)
+
 ## Source code
 [Separator.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Separator.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/slider.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/slider.md
@@ -3,5 +3,8 @@ Title: Slider
 ---
 The `Slider` control is a control that lets the user select from a range of values by moving a Thumb control along a track.
 
+## Reference
+[Slider](http://reference.avaloniaui.net/api/Avalonia.Controls/Slider/)
+
 ## Source code
 [Slider.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Slider.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/stackpanel.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/stackpanel.md
@@ -3,5 +3,8 @@ Title: StackPanel
 ---
 The `StackPanel` control is a `Panel` which lays out its children by stacking them horizontally or vertically.
 
+## Reference
+[StackPanel](http://reference.avaloniaui.net/api/Avalonia.Controls/StackPanel/)
+
 ## Source code
 [StackPanel.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/StackPanel.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/tabcontrol.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/tabcontrol.md
@@ -88,5 +88,8 @@ The grey part is the `TabItem`... Yes, the `TabItem` includes the tab **AND** th
 </Window.Styles>
 ```
 
+## Reference
+[TabControl](http://reference.avaloniaui.net/api/Avalonia.Controls/TabControl/)
+
 ## Source code
 [TabControl.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/TabControl.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/tabstrip.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/tabstrip.md
@@ -3,5 +3,8 @@ Title: TabStrip
 ---
 Displays a strip of selectable tabs.
 
+## Reference
+[TabStrip](http://reference.avaloniaui.net/api/Avalonia.Controls/TabStrip/)
+
 ## Source code
 [TabStrip.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Primitives/TabStrip.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/textblock.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/textblock.md
@@ -3,5 +3,8 @@ Title: TextBlock
 ---
 The `TextBlock` control allows for the display of label-like text in the interface.
 
+## Reference
+[TextBlock](http://reference.avaloniaui.net/api/Avalonia.Controls/TextBlock/)
+
 ## Source code
 [TextBlock.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/TextBlock.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/textbox.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/textbox.md
@@ -3,6 +3,9 @@ Title: Textbox
 ---
 The `TextBox` control is an editable text field where a user can input text.
 
+## Reference
+[TextBox](http://reference.avaloniaui.net/api/Avalonia.Controls/TextBox/)
+
 ## Source code
 [TextBox.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/TextBox.cs)
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/tooltip.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/tooltip.md
@@ -14,6 +14,9 @@ The `ToolTip` is a control that pops up with hint text when hovered over the app
 |`ShowDelay`|Gets or sets the delay for the tooltip to appear. Default value is 400.|
 |`IsOpen`|Gets or sets a value indicating whether the tooltip is currently showing.|
 
+## Reference
+[ToolTip](http://reference.avaloniaui.net/api/Avalonia.Controls/ToolTip/)
+
 ## Source code
 [ToolTip.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/ToolTip.cs)
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/treeview.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/treeview.md
@@ -3,5 +3,8 @@ Title: TreeView
 ---
 The `TreeView` is a control that presents hierarchical tree data and allows selection of it.
 
+## Reference
+[TreeView](http://reference.avaloniaui.net/api/Avalonia.Controls/TreeView/)
+
 ## Source code
 [TreeView.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/TreeView.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/usercontrol.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/usercontrol.md
@@ -18,5 +18,8 @@ an application. For information on how to create new `UserControl` classes from 
 |--------|-----------|
 |`Content`|The content to display in the control|
 
+## Reference
+[UserControl](http://reference.avaloniaui.net/api/Avalonia.Controls/UserControl/)
+
 ## Source code
 [UserControl.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/UserControl.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/viewbox.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/viewbox.md
@@ -36,9 +36,11 @@ been rendered at around 22 dip height. With the `Viewbox` it will be displayed w
 |Uniform      |The content is resized to fit in the destination dimensions while preserving its native aspect ratio.|
 |UniformToFill|The content is resized to completely fill the destination rectangle while preserving its native aspect ratio. A portion of the content may not be visible if the aspect ratio of the content does not match the aspect ratio of the allocated space.|
 
-
-# Pseudoclasses
-
+## Pseudoclasses
 None
-# Source code
+
+## Reference
+[Viewbox](http://reference.avaloniaui.net/api/Avalonia.Controls/Viewbox/)
+
+## Source code
 [Viewbox.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Viewbox.cs)

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/window.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/window.md
@@ -17,6 +17,9 @@ how to create new window classes from templates see the [quickstart](/docs/quick
 |`SizeToContent`|Describes the window's auto-sizing behavior|
 |`WindowState`|The minimized/maximized state of the window|
 
+## Reference
+[Window](http://reference.avaloniaui.net/api/Avalonia.Controls/Window/)
+
 ## Source code
 [Window.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Window.cs)
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/wrappanel.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/wrappanel.md
@@ -3,5 +3,8 @@ Title: WrapPanel
 ---
 The `WrapPanel` control is a [`Panel`](/docs/controls/panel){target="_blank"} which positions child elements in sequential position from left to right, breaking content to the next line at the edge of the containing box. Subsequent ordering happens sequentially from top to bottom or from right to left, depending on the value of the Orientation property. 
 
+## Reference
+[WrapPanel](http://reference.avaloniaui.net/api/Avalonia.Controls/WrapPanel/)
+
 ## Source code
 [WrapPanel.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/WrapPanel.cs)


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Adds a link to the reference page of all controls in the docs.

**What is the current behavior?**
Users would see no reference link on a control's page. Often it's useful to read about what properties a control uses, and the reference is the best place to do that. Users would need to manually browse to API and search up the control to access its page.

**What is the new behavior?**
Users can now immediately visit the reference page on the same page as the documentation for that control.