### PR TITLE
Title casing typo in TextBox docs

### DIFF
--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/textbox.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/textbox.md
@@ -1,5 +1,5 @@
 ---
-Title: Textbox
+Title: TextBox
 ---
 The `TextBox` control is an editable text field where a user can input text.
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
A simple casing error in the docs title



**What is the current behavior?**
It shows Textbox



**What is the new behavior?**
Now it shows TextBox


