### PR TITLE
Removing unused font-awesome #174

### DIFF
--- a/src/AvaloniaUI.Net/Pages/Shared/_Head.cshtml
+++ b/src/AvaloniaUI.Net/Pages/Shared/_Head.cshtml
@@ -27,7 +27,6 @@
   </environment>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat+Alternates:wght@700&family=Montserrat:wght@300;500;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/css/solid.min.css">
   
   <!-- JS declarations were moved to the Footer -->
   


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Removes unused Font Awesome reference as reported in #174 



**What is the current behavior?**
Font Awesome is loaded from CDN



**What is the new behavior?**
The reference is removed as it is not used in the whole site.


Fixes #174 