### PR TITLE
Revert "Removing unused font-awesome #174"

### DIFF
--- a/src/AvaloniaUI.Net/Pages/Shared/_Head.cshtml
+++ b/src/AvaloniaUI.Net/Pages/Shared/_Head.cshtml
@@ -27,6 +27,7 @@
   </environment>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat+Alternates:wght@700&family=Montserrat:wght@300;500;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/css/solid.min.css">
   
   <!-- JS declarations were moved to the Footer -->
   


### PR DESCRIPTION
@Carlos487 had to revert #174 - font awesome is used for the expand chevrons in the docs sidebar:

https://github.com/AvaloniaUI/avaloniaui.net/blob/master/src/AvaloniaUI.Net/wwwroot/css/docs.css#L89

Reverts AvaloniaUI/avaloniaui.net#182