### PR TITLE
Update line-height to 1.75 for docs/blog posts.

### DIFF
--- a/src/AvaloniaUI.Net/wwwroot/css/content.css
+++ b/src/AvaloniaUI.Net/wwwroot/css/content.css
@@ -22,6 +22,7 @@
 
 article {
   padding: var(--padding-large);
+  line-height: 1.75;
 }
 
   article img {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Use a more readable line spacing for docs and blog posts, as suggested in #136
