### PR TITLE
Updating FontAwesome and menu icon

### DIFF
--- a/src/AvaloniaUI.Net/Pages/Shared/_Head.cshtml
+++ b/src/AvaloniaUI.Net/Pages/Shared/_Head.cshtml
@@ -27,7 +27,7 @@
   </environment>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat+Alternates:wght@700&family=Montserrat:wght@300;500;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/css/solid.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/css/all.min.css">
   
   <!-- JS declarations were moved to the Footer -->
   

--- a/src/AvaloniaUI.Net/Pages/Shared/_Navbar.cshtml
+++ b/src/AvaloniaUI.Net/Pages/Shared/_Navbar.cshtml
@@ -16,7 +16,7 @@
       <li class="nav-item"><a href="/docs">Documentation</a></li>
       <li class="nav-item"><a href="/contributing">Contributing</a></li>
       <li class="nav-item"><a href="http://reference.avaloniaui.net/api" target="_blank" rel="noopener">API</a></li>
-      <li class="nav-item"><a href="https://github.com/AvaloniaUI/Avalonia" target="_blank" rel="noopener">Source</a></li>
+      <li class="nav-item"><a href="https://github.com/AvaloniaUI/Avalonia" target="_blank" rel="noopener"><i class="fab fa-github"></i> Source</a></li>
     </ul>
   </nav>
 </header>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Updated FontAwesome version, loading full version to access more icons, which can be useful in other areas of the site and adding Github icon to the menu.



**What is the current behavior?**
Loading partial css from font-awesome, no icon on menu.



**What is the new behavior?**
Loading full updated FontAwesome version and adding Github icon to the menu, as other 

![2020-08-19 19_10_01-Avalonia UI Framework and 2 more pages - Personal - Microsoft​ Edge](https://user-images.githubusercontent.com/1598555/90702185-3f91c400-e250-11ea-991c-7d115b029b04.png)



