### PR TITLE
Automatic Deploy via Systemd and Friends

### DIFF
--- a/ava.service.sh
+++ b/ava.service.sh
@@ -5,17 +5,37 @@ sudo dpkg -i packages-microsoft-prod.deb
 sudo apt-get update; \
   sudo apt-get install -y apt-transport-https && \
   sudo apt-get update && \
-  sudo apt-get install -y dotnet-runtime-3.1
+  sudo apt-get install -y dotnet-runtime-3.1 aspnetcore-runtime-3.1
+
+# Prepare the 'azure' user.
+sudo -i
+adduser --system --disabled-password --shell /bin/bash --home /home/azure azure
+echo "azure ALL= NOPASSWD: /bin/systemctl stop ava.service, /bin/systemctl restart ava.service" >> /etc/sudoers
+
+# Prepare the directories.
+mkdir -p /home/azure/avaloniaui.net
+mkdir -p /tmp/avaloniaui.net
+chmod 777 /home/azure/avaloniaui.net
+chmod 777 /tmp/avaloniaui.net
+
+# Create /home/reload.sh
+cat > /home/azure/reload.sh <<EOF
+sudo systemctl stop ava.service > /dev/null 2>&1
+rm -r /home/azure/avaloniaui.net/* > /dev/null 2>&1 || true
+cp -r /tmp/avaloniaui.net/* /home/azure/avaloniaui.net/
+rm -r /tmp/avaloniaui.net/* > /dev/null 2>&1 || true
+chmod 777 /home/azure/avaloniaui.net/AvaloniaUI.Net
+sudo systemctl restart ava.service
+EOF
+chmod 777 /home/azure/reload.sh
 
 # Register ava.service as a new systemd service.
-sudo -i
 cat > /etc/systemd/system/ava.service <<EOF
 [Unit]
 Description=AvaloniaUI .NET Core App
-
 [Service]
-WorkingDirectory=/home/avaloniaui.net
-ExecStart=/home/avaloniaui.net/AvaloniaUI.Net
+WorkingDirectory=/home/azure/avaloniaui.net
+ExecStart=/home/azure/avaloniaui.net/AvaloniaUI.Net
 Restart=always
 RestartSec=10
 KillSignal=SIGINT
@@ -23,7 +43,22 @@ SyslogIdentifier=dotnet-ava
 User=root
 Environment=ASPNETCORE_ENVIRONMENT=Production
 Environment=DOTNET_PRINT_TELEMETRY_MESSAGE=false
-
+Environment=ASPNETCORE_URLS="http://*:80"
 [Install]
 WantedBy=multi-user.target
 EOF
+
+# Enable the new systemd service.
+systemctl daemon-reload
+systemctl enable ava.service 2>&1
+
+# Generate SSH keys.
+su azure
+ssh-keygen -t rsa -P "" -f /home/azure/azure
+mkdir -p /home/azure/.ssh
+chmod -R 700 /home/azure/.ssh
+touch /home/azure/.ssh/authorized_keys
+cp -f /home/azure/azure.pub /home/azure/.ssh/authorized_keys
+sed -i.old '1s;^;no-port-forwarding,no-x11-forwarding,no-agent-forwarding ;' /home/azure/.ssh/authorized_keys
+echo "Add this key to your Azure service connection."
+cat /home/azure/azure

--- a/ava.service.sh
+++ b/ava.service.sh
@@ -1,0 +1,29 @@
+# Install .NET Core 3.1.
+# According to https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#install-the-sdk 
+wget https://packages.microsoft.com/config/ubuntu/19.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+sudo apt-get update; \
+  sudo apt-get install -y apt-transport-https && \
+  sudo apt-get update && \
+  sudo apt-get install -y dotnet-runtime-3.1
+
+# Register ava.service as a new systemd service.
+sudo -i
+cat > /etc/systemd/system/ava.service <<EOF
+[Unit]
+Description=AvaloniaUI .NET Core App
+
+[Service]
+WorkingDirectory=/home/avaloniaui.net
+ExecStart=/home/avaloniaui.net/AvaloniaUI.Net
+Restart=always
+RestartSec=10
+KillSignal=SIGINT
+SyslogIdentifier=dotnet-ava
+User=root
+Environment=ASPNETCORE_ENVIRONMENT=Production
+Environment=DOTNET_PRINT_TELEMETRY_MESSAGE=false
+
+[Install]
+WantedBy=multi-user.target
+EOF

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,18 +25,6 @@ steps:
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
   condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], false))
-- task: SSH@0
-  inputs:
-    displayName: "Prepare Host Directory"
-    sshEndpoint: 'production-server'
-    runOptions: 'commands'
-    failOnStdErr: true
-    commands: |
-      sudo mkdir -p /home/avaloniaui.net
-      sudo mkdir -p /tmp/avaloniaui.net
-      sudo chmod 777 /home/avaloniaui.net
-      sudo chmod 777 /tmp/avaloniaui.net
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 - task: CopyFilesOverSSH@0
   displayName: 'Upload Artifacts to Host'
   inputs:
@@ -52,14 +40,5 @@ steps:
     displayName: 'Start Host App'
     sshEndpoint: 'production-server'
     runOptions: 'commands'
-    commands: |
-     sudo systemctl stop ava.service > /dev/null 2>&1
-     sudo rm -r /home/avaloniaui.net/* > /dev/null 2>&1 || true
-     sudo cp -r /tmp/avaloniaui.net/* /home/avaloniaui.net/
-     sudo rm -r /tmp/avaloniaui.net/* > /dev/null 2>&1 || true
-     sudo chmod 777 /etc/systemd/system/ava.service
-     sudo chmod 777 /home/avaloniaui.net/AvaloniaUI.Net
-     sudo systemctl daemon-reload
-     sudo systemctl enable ava.service 2>&1
-     sudo systemctl restart ava.service
+    commands: '/home/azure/reload.sh'
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,3 +25,41 @@ steps:
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
   condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], false))
+- task: SSH@0
+  inputs:
+    displayName: "Prepare Host Directory"
+    sshEndpoint: 'production-server'
+    runOptions: 'commands'
+    failOnStdErr: true
+    commands: |
+      sudo mkdir -p /home/avaloniaui.net
+      sudo mkdir -p /tmp/avaloniaui.net
+      sudo chmod 777 /home/avaloniaui.net
+      sudo chmod 777 /tmp/avaloniaui.net
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+- task: CopyFilesOverSSH@0
+  displayName: 'Upload Artifacts to Host'
+  inputs:
+    sshEndpoint: 'production-server'
+    sourceFolder: $(Build.ArtifactStagingDirectory)
+    contents: '**/*'
+    targetFolder: '/tmp/avaloniaui.net'
+    cleanTargetFolder: true
+    overwrite: true
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+- task: SSH@0
+  inputs:
+    displayName: 'Start Host App'
+    sshEndpoint: 'production-server'
+    runOptions: 'commands'
+    commands: |
+     sudo systemctl stop ava.service > /dev/null 2>&1
+     sudo rm -r /home/avaloniaui.net/* > /dev/null 2>&1 || true
+     sudo cp -r /tmp/avaloniaui.net/* /home/avaloniaui.net/
+     sudo rm -r /tmp/avaloniaui.net/* > /dev/null 2>&1 || true
+     sudo chmod 777 /etc/systemd/system/ava.service
+     sudo chmod 777 /home/avaloniaui.net/AvaloniaUI.Net
+     sudo systemctl daemon-reload
+     sudo systemctl enable ava.service 2>&1
+     sudo systemctl restart ava.service
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Clear and concise description of this PR. -->

This PR implements automatic deploy of the artifacts built by Azure Pipelines to a dedicated server via SSH. Originally started work in https://github.com/AvaloniaUI/avaloniaui.net/pull/198 however that one was accidentally closed via a force-push (a vital thing in CI setup). With this PR, the general deployment process consists of the following steps:
1. Run `ava.service.sh` on a clean Ubuntu machine. This installs .NET Core 3.1 and configures automatic restarts on failures.
2. Add a new service connection to the host machine via Azure DevOps (`Project Settings -> Pipelines -> Service Connections -> New service connection -> SSH`), service connection name should be `production-server`. Use the private key generated by `ava.service.sh`, and `azure` as the user name.
2. Push something to the main `master` branch and the app will auto-reload with new content after a successful CI build.

I've set up a sample CI for my `avaloniaui.net` repository fork so one could view an example of a successful job https://worldbeater.visualstudio.com/Camelotia/_build/results?buildId=583&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=12f1170f-54f2-53f3-20dd-22fc7dff55f9

