### PR TITLE
Fix TabStrip API Reference Link

### DIFF
--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/tabstrip.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/tabstrip.md
@@ -4,7 +4,7 @@ Title: TabStrip
 Displays a strip of selectable tabs.
 
 ## Reference
-[TabStrip](http://reference.avaloniaui.net/api/Avalonia.Controls/TabStrip/)
+[TabStrip](http://reference.avaloniaui.net/api/Avalonia.Controls.Primitives/TabStrip/)
 
 ## Source code
 [TabStrip.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/Primitives/TabStrip.cs)


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Clear and concise description of this PR. -->

Fixes the link to the API Reference for the `TabStrip` control.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Link is broken.

**What is the new behavior?**
<!-- Describe what's changed. -->

Link now points to correct location.
