### PR TITLE
Fix XAML "find out more" link on homepage.

### DIFF
--- a/src/AvaloniaUI.Net/Pages/Index.cshtml
+++ b/src/AvaloniaUI.Net/Pages/Index.cshtml
@@ -30,7 +30,7 @@
       <p><strong>Avalonia uses a XAML dialect that should feel immediately familiar to anyone coming from WPF, UWP and Xamarin Forms.</strong>
       <p>Avalonia supports binding, MVVM, lookless controls and data templates just as you’d expect from a XAML framework.</p>
     </div>
-    <a class="button dock-bottom" href="/docs/quickstart/xaml">Find out more</a>
+    <a class="button dock-bottom" href="/docs/quickstart/intro-to-xaml">Find out more</a>
   </section>
 
   <section id="xplat" class="bg-gray2 dock-grid">


### PR DESCRIPTION
**What kind of change does this PR introduce?**

The "Find out more" link under XAML on the homepage was a broken link. Fixes that.