### PR TITLE
Fix dash typo

### DIFF
--- a/src/AvaloniaUI.Net/Services/MarkdownDocumentLoader.cs
+++ b/src/AvaloniaUI.Net/Services/MarkdownDocumentLoader.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using AvaloniaUI.Net.Models;
 using YamlDotNet.Core;
@@ -15,8 +16,7 @@ namespace AvaloniaUI.Net.Services
             where TDocument : class, IMarkdownDocument, new()
             where TFrontMatter : class, IMarkdownFrontMatter, new()
         {
-            using var s = new FileStream(path, FileMode.Open);
-            using var r = new StreamReader(s);
+            using var r = File.OpenText(path);
             var line = await r.ReadLineAsync();
             var result = new TDocument();
 
@@ -25,7 +25,7 @@ namespace AvaloniaUI.Net.Services
                 return null;
             }
 
-            if (line.StartsWith("---"))
+            if (line.StartsWith("---", StringComparison.Ordinal))
             {
                 result.FrontMatter = ParseFrontMatter<TFrontMatter>(r);
             }
@@ -40,8 +40,7 @@ namespace AvaloniaUI.Net.Services
         public TFrontMatter? LoadFrontMatter<TFrontMatter>(string path)
             where TFrontMatter : class, IMarkdownFrontMatter, new()
         {
-            using var s = new FileStream(path, FileMode.Open);
-            using var r = new StreamReader(s);
+            using var r = File.OpenText(path);
             return ParseFrontMatter<TFrontMatter>(r);
         }
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/binding/attached-properties.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/binding/attached-properties.md
@@ -1,4 +1,4 @@
-----
+---
 Title: Creating and binding Attached Properties
 Order: 90
 ---


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fix 'Mapping values are not allowed in this context' in YamlDotNet. Also, for the future, I used this advice https://github.com/aaubry/YamlDotNet/issues/376#issuecomment-500478360



**What is the current behavior?**
Parsing error occurs in my conditions. On server page of https://avaloniaui.net/docs/binding/attached-properties :
![image](https://user-images.githubusercontent.com/2669927/93705817-f6c47800-fb39-11ea-8584-2b249a2bef3b.png)




**What is the new behavior?**
Parses without errors


Fixes #204