### PR TITLE
Use http for reference api

### DIFF
--- a/src/AvaloniaUI.Net/Startup.cs
+++ b/src/AvaloniaUI.Net/Startup.cs
@@ -57,7 +57,7 @@ namespace AvaloniaUI.Net
             });
 
             var redirect = new RewriteOptions()
-                .AddRedirect("api/(.*)", "//reference.avaloniaui.net/api/$1");
+                .AddRedirect("api/(.*)", "http://reference.avaloniaui.net/api/$1");
             app.UseRewriter(redirect);
         }
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Use http for reference api (I do not know how to more correctly specify to redirect to http)



**What is the current behavior?**
For example https://avaloniaui.net/api/Avalonia.Controls/ContentControl/4B02A756 redirected to https://reference.avaloniaui.net/api/Avalonia.Controls/ContentControl/4B02A756



**What is the new behavior?**
https://avaloniaui.net/api/Avalonia.Controls/ContentControl/4B02A756 redirected to http://reference.avaloniaui.net/api/Avalonia.Controls/ContentControl/4B02A756


