### PR TITLE
Fix ref to Control.Styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,6 +262,9 @@ paket-files/
 .idea/
 *.sln.iml
 
+# VS Code
+.vscode/
+
 # CodeRush
 .cr/
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/styles/styles.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/styles/styles.md
@@ -20,7 +20,7 @@ point and font weight to bold:
 ```
 
 Styles can be defined on any control or on the `Application` object by adding them to the 
-[`Control.Styles`](/api/Avalonia.Controls/Control/4145DF25) or 
+[`Control.Styles`](/api/Avalonia/StyledElement/0A46A84A) or 
 [`Application.Styles`](/api/Avalonia/Application/04017CAF) collections.
 
 ```xml


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fix ref to `Control.Styles` (Inherited from `StyledElement`)



**What is the current behavior?**
404 Not Found: http://reference.avaloniaui.net/api/Avalonia.Controls/Control/4145DF25 (after #209 there will be http)



**What is the new behavior?**
Work: http://reference.avaloniaui.net/api/Avalonia/StyledElement/0A46A84A


