### PR TITLE
Fixed bitmap converter target type check

### DIFF
--- a/src/AvaloniaUI.Net/wwwroot/docs/controls/image.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/controls/image.md
@@ -47,7 +47,7 @@ public class BitmapAssetValueConverter : IValueConverter
         if (value == null)
             return null;
 
-        if (value is string rawUri && targetType == typeof(IBitmap))
+        if (value is string rawUri && targetType.IsAssignableFrom(typeof(Bitmap)))
         {
             Uri uri;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Fixed bitmap converter target type check.

**What is the current behavior?**

The converter fails because the type of `Image.Source` was changed: `IBitmap` -> `IImage`.

**What is the new behavior?**

As the converter returns a `Bitmap`, accept any target type assignable from it.

Fixes #235