### PR TITLE
Advanced tutorial fixes

### DIFF
--- a/src/AvaloniaUI.Net/Pages/Docs/Index.cshtml
+++ b/src/AvaloniaUI.Net/Pages/Docs/Index.cshtml
@@ -5,7 +5,7 @@
 
 @model AvaloniaUI.Net.Pages.Docs.IndexModel
 @{
-  ViewData["Title"] = "Avalonia Docs";
+  ViewData["Title"] = "Avalonia Docs - " + (Model.Article?.Title ?? "[untitled]");
   Layout = "_DocsLayout";
 }
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/add-controls.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/add-controls.md
@@ -9,7 +9,7 @@ Lets start by adding a `Button` to the `MainWindow`. The button will allow the `
 
 In `MainWindow.axaml` change the code as follows, adding a Button inside the Panel.
 
-```xaml
+```xml
 <Panel>
     <ExperimentalAcrylicBorder IsHitTestVisible="False">
         <ExperimentalAcrylicBorder.Material>
@@ -50,7 +50,7 @@ public class MainWindowViewModel : ViewModelBase
 
 Pressing the `Debug Button` again to run the program we can see we have a button and when clicked setting a breakpoint inside the `BuyMusicCommand` code we can see that the code is executed when its hit.
 
-![buy-button](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/buy-button.png)
+![buy-button](/docs/advanced-tutorial/images/buy-button.png)
 
 Let's position the button to the top right of the screen and make it look a bit nicer.
 
@@ -58,7 +58,7 @@ Place the `<Button>` element inside a simple `<Panel>` element.
 
 The simplest way to control the layout of a control is with the  `HorizontalAlignment`and `VerticalAlignment` properties.
 
-```xaml
+```xml
 <Panel Margin="40">
   <Button Content="Buy Music" Command="{Binding BuyMusicCommand}" HorizontalAlignment="Right" VerticalAlignment="Top" />
 </Panel>
@@ -76,7 +76,7 @@ Find the name, in this case `store_microsoft_regular`.
 
 There should be some code similar to:
 
-```xaml
+```xml
 <StreamGeometry x:Key="store_microsoft_regular">M11.5 9.5V13H8V9.5H11.5Z M11.5 17.5V14H8V17.5H11.5Z M16 9.5V13H12.5V9.5H16Z M16 17.5V14H12.5V17.5H16Z M8 6V3.75C8 2.7835 8.7835 2 9.75 2H14.25C15.2165 2 16 2.7835 16 3.75V6H21.25C21.6642 6 22 6.33579 22 6.75V18.25C22 19.7688 20.7688 21 19.25 21H4.75C3.23122 21 2 19.7688 2 18.25V6.75C2 6.33579 2.33579 6 2.75 6H8ZM9.5 3.75V6H14.5V3.75C14.5 3.61193 14.3881 3.5 14.25 3.5H9.75C9.61193 3.5 9.5 3.61193 9.5 3.75ZM3.5 18.25C3.5 18.9404 4.05964 19.5 4.75 19.5H19.25C19.9404 19.5 20.5 18.9404 20.5 18.25V7.5H3.5V18.25Z</StreamGeometry>
 ```
 
@@ -86,13 +86,13 @@ Lets create a file just for Icons.
 
 In Rider right click on the project and select `Add` -> `Avalonia Styles`
 
-![add-styles](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/add-styles.png)
+![add-styles](/docs/advanced-tutorial/images/add-styles.png)
 
 Enter the name `Icons` when prompted and press `Enter`.
 
 A new `xaml` file will be created that we can put styles or icons inside.
 
-```xaml
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
@@ -107,7 +107,7 @@ A new `xaml` file will be created that we can put styles or icons inside.
 
 Add your Icon code inside wrapped in a `Style` element as a resource like so.
 
-```xaml
+```xml
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Design.PreviewWith>
@@ -127,7 +127,7 @@ Add your Icon code inside wrapped in a `Style` element as a resource like so.
 
 Open `App.axaml` and add a `StyleInclude` so that the `Icons.axaml`can be loaded.
 
-```xaml
+```xml
 <Application.Styles>
     <FluentTheme Mode="Dark"/>
     <StyleInclude Source="avares://Avalonia.MusicStore/Icons.axaml" />
@@ -138,7 +138,7 @@ Now build the application so that the Icons are available in the previewer.
 
 Return to `MainWindow.axaml`, we can add the Icon to the Button like so...
 
-```xaml
+```xml
 <Button Margin="40" HorizontalAlignment="Right" VerticalAlignment="Top" Command="{Binding BuyMusicCommand}">
     <PathIcon Data="{StaticResource store_microsoft_regular}" />
 </Button>
@@ -146,5 +146,5 @@ Return to `MainWindow.axaml`, we can add the Icon to the Button like so...
 
 Running the application we now have a nice button.
 
-![pretty-button](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/pretty-button.png)
+![pretty-button](/docs/advanced-tutorial/images/pretty-button.png)
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/add-dialog-content.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/add-dialog-content.md
@@ -34,7 +34,7 @@ Build the project so that the previewer will work.
 
 Declare a `<DockPanel>`.
 
-```xaml
+```xml
 <DockPanel>
    
 </DockPanel>
@@ -44,7 +44,7 @@ Declare a `<DockPanel>`.
 
 Inside the `DockPanel` add a `<StackPanel>`. Set `DockPanel.Dock="Top"` on the `StackPanel` so that it will be positioned at the top.
 
-```xaml
+```xml
 <DockPanel>
     <StackPanel DockPanel.Dock="Top">
     
@@ -56,7 +56,7 @@ Inside the `DockPanel` add a `<StackPanel>`. Set `DockPanel.Dock="Top"` on the `
 
 Inside the `StackPanel` add a `TextBox` and a `ProgressBar`.
 
-```xaml
+```xml
 <DockPanel>
     <StackPanel DockPanel.Dock="Top">
         <TextBox Text="{Binding SearchText}" Watermark="Search for Albums...." />
@@ -128,7 +128,7 @@ Back inside our DockPanel add a `Button` and set it to Dock at the bottom. Set i
 
 Then bind its `Command` to `BuyMusicCommand`.
 
-```xaml
+```xml
 <DockPanel>
     <StackPanel DockPanel.Dock="Top">
         <TextBox Text="{Binding SearchText}" Watermark="Search for Albums...." />
@@ -162,7 +162,7 @@ Add a `ListBox` to the `DockPanel`. Since this is the last item in the Panel it 
 
 Bind the `Items` and `SelectedItem` properties as shown, set the `Background` to `Transparent`. Add a `Margin` or `0 20`. This mean left and right sides have 0 and top and bottom have 20. This creates some space between the other controls.
 
-```xaml
+```xml
 <ListBox Items="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}" Background="Transparent" Margin="0 20" />
 ```
 
@@ -198,7 +198,7 @@ Since we are using `ObservableCollection` when we `bind` the `ListBox`s `Items` 
 
 The `ListBox` will see that the `SearchResults` has an item inside it, it will check the type of the item, which will be `AlbumViewModel`. The `ListBox` will then see if it has a `DataTemplate` for that type, which we dont. However it will find at the root of the application in `App.axaml`
 
-```xaml
+```xml
 <Application.DataTemplates>
     <local:ViewLocator />
 </Application.DataTemplates>
@@ -223,19 +223,19 @@ Before we can run this we need to add our `MusicStoreView` to our `MusicStoreWin
 
 At the top of `MusicStoreWindow.axaml` you will find some lines that begin `xmlns:x` etc.. add a line:
 
-```xaml
+```xml
 xmlns:local="using:Avalonia.MusicStore.Views"
 ```
 
 Then inside the `<Panel>` add.
 
-```xaml
+```xml
 <local:MusicStoreView />
 ```
 
 You `MusicStoreWindow.axaml` should look like this.
 
-```xaml
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -269,7 +269,7 @@ You `MusicStoreWindow.axaml` should look like this.
 
 Run the application:
 
-![text-list](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/text-list.png)
+![text-list](/docs/advanced-tutorial/images/text-list.png)
 
 Our items are showing in the List... but not very visual.
 
@@ -289,7 +289,7 @@ public class AlbumViewModel : ViewModelBase
 
 In your newly created `AlbumView` add the following code:
 
-```xaml
+```xml
 <StackPanel Spacing="5" Width="200">
     <Border CornerRadius="10" ClipToBounds="True">
         <Panel Background="#7FFF22DD">
@@ -312,7 +312,7 @@ The border contains a `Panel` with a `Background` set, using a hexadecimal colou
 
 This `Panel` contains an `Image`, and a `PathIcon` infront of it. The source for the Icon to go in `Icons.axaml` is :
 
-```xaml
+```xml
 <StreamGeometry x:Key="music_regular">M11.5,2.75 C11.5,2.22634895 12.0230228,1.86388952 12.5133347,2.04775015 L18.8913911,4.43943933 C20.1598961,4.91511241 21.0002742,6.1277638 21.0002742,7.48252202 L21.0002742,10.7513533 C21.0002742,11.2750044 20.4772513,11.6374638 19.9869395,11.4536032 L13,8.83332147 L13,17.5 C13,17.5545945 12.9941667,17.6078265 12.9830895,17.6591069 C12.9940859,17.7709636 13,17.884807 13,18 C13,20.2596863 10.7242052,22 8,22 C5.27579485,22 3,20.2596863 3,18 C3,15.7403137 5.27579485,14 8,14 C9.3521238,14 10.5937815,14.428727 11.5015337,15.1368931 L11.5,2.75 Z M8,15.5 C6.02978478,15.5 4.5,16.6698354 4.5,18 C4.5,19.3301646 6.02978478,20.5 8,20.5 C9.97021522,20.5 11.5,19.3301646 11.5,18 C11.5,16.6698354 9.97021522,15.5 8,15.5 Z M13,3.83223733 L13,7.23159672 L19.5002742,9.669116 L19.5002742,7.48252202 C19.5002742,6.75303682 19.0477629,6.10007069 18.3647217,5.84393903 L13,3.83223733 Z</StreamGeometry>
 ```
 
@@ -326,11 +326,11 @@ We shall come back to the `Bindings` in a moment, for now lets run the applicati
 
 As can be seen the albums are displayed vertically. However it would be nice to have them horizontally and wrap around.
 
-![image-20210310010932979](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/image-20210310010932979.png)
+![image-20210310010932979](/docs/advanced-tutorial/images/image-20210310010932979.png)
 
 Luckily `ListBox` provides a solution to this with something called `ItemsPanelTemplate`. By default the `ListBox` has its `ItemPanel` property set to an `ItemsPanelTemplate` which contains a `StackPanel`, we can change this to a `WrapPanel` like so.
 
-```xaml
+```xml
 <ListBox Items="{Binding SearchResults}" SelectedItem="{Binding SelectedAlbum}" Background="Transparent" Margin="0 20">
     <ListBox.ItemsPanel>
         <ItemsPanelTemplate>
@@ -342,7 +342,7 @@ Luckily `ListBox` provides a solution to this with something called `ItemsPanelT
 
 Now when we run the application we get:
 
-![image-20210310011526700](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/image-20210310011526700.png) 
+![image-20210310011526700](/docs/advanced-tutorial/images/image-20210310011526700.png) 
 
 As our list gets more items the will wrap around onto the next line, and the user will be able to scroll.
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/add-to-user-collection.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/add-to-user-collection.md
@@ -11,7 +11,7 @@ Modify the `MainWindow.axaml` so that it places the existing `Button` inside a p
 
 We can then use an `ItemsControl` instead of a `ListBox` as we did before. An `ItemsControl` is the exact same as a `ListBox` except it doesnt allow the user to select anything.
 
-```xaml
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:Avalonia.MusicStore.ViewModels"
@@ -106,6 +106,6 @@ Notice we check the result for `null`, this is because the `user` may have cance
 
 Lets run the program and see if it works.
 
-![image-20210310175949319](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/image-20210310175949319.png)
+![image-20210310175949319](/docs/advanced-tutorial/images/image-20210310175949319.png)
 
 For the finishing touch we simply need to add persistance to the application.

--- a/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/create-a-modern-window.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/create-a-modern-window.md
@@ -11,7 +11,7 @@ Lets try and make this look a little more modern by applying `Dark` mode and som
 
    Change the FluentTheme Mode from Light to Dark.
 
-   ```xaml
+```xml
    <FluentTheme Mode="Dark"/>
    ```
 
@@ -29,13 +29,13 @@ Lets try and make this look a little more modern by applying `Dark` mode and som
 
    
 
-   ![dark-mode-preview](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/dark-mode-preview.png)
+   ![dark-mode-preview](/docs/advanced-tutorial/images/dark-mode-preview.png)
 
    
 
 4. After where it says `Title="Avalonia.MusicStore"` add the following code:
 
-   ```xaml
+```xml
    <Window xmlns="https://github.com/avaloniaui"
            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
            xmlns:vm="using:Avalonia.MusicStore.ViewModels"
@@ -48,7 +48,7 @@ Lets try and make this look a little more modern by applying `Dark` mode and som
            
            TransparencyLevelHint="AcrylicBlur"
            Background="Transparent">
-   ```
+```
 
    This will make the Window Transparent and apply a Blur.
 
@@ -56,7 +56,7 @@ Lets try and make this look a little more modern by applying `Dark` mode and som
 
    To apply acrylic to the window, that we can tint and customize for a modern look, replace the `<TextBlock>` with the following code:
 
-   ```xaml
+```xml
    <Window xmlns="https://github.com/avaloniaui"
            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
            xmlns:vm="using:Avalonia.MusicStore.ViewModels"
@@ -85,13 +85,13 @@ Lets try and make this look a little more modern by applying `Dark` mode and som
            </ExperimentalAcrylicBorder>
        </Panel>
    </Window>
-   ```
+```
 
 Now click the `Debug` `Button` to run the application again.
 
 Notice we have a nice acrylic window effect. Shame about the titlebar though. Lets see how we can make that blend in a bit more.
 
-![acrylic-material](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/acrylic-material.png)
+![acrylic-material](/docs/advanced-tutorial/images/acrylic-material.png)
 
 *Note, Linux users can not yet take advantage of this due to limitations of X11. The code will run and the window will still work on Linux, but the full effect will not be realised.
 
@@ -103,7 +103,7 @@ Notice we have a nice acrylic window effect. Shame about the titlebar though. Le
 
    To enable this mode on the `Window` element  set the `ExtendClientAreaToDecorationsHint` property to `True`.
 
-   ```xaml
+```xml
    <Window xmlns="https://github.com/avaloniaui"
            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
            xmlns:vm="using:Avalonia.MusicStore.ViewModels"
@@ -117,10 +117,10 @@ Notice we have a nice acrylic window effect. Shame about the titlebar though. Le
            Background="Transparent"
            
            ExtendClientAreaToDecorationsHint="True">
-   ```
+```
 
    Press the `Debug` button again to run.
 
-![full-acrylic-window](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/full-acrylic-window.png)
+![full-acrylic-window](/docs/advanced-tutorial/images/full-acrylic-window.png)
 
 Perfect, a modern looking Window, Avalonia is able to render every pixel.

--- a/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/create-project.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/create-project.md
@@ -11,11 +11,11 @@ At the bottom on the left hand side under the heading `Other` you will see `Aval
 
 Click the `Create` button.
 
-<img src="/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/CreateSolution.png" alt="CreateSolution" style="zoom:50%;" />
+<img src="/docs/advanced-tutorial/images/CreateSolution.png" alt="CreateSolution" style="zoom:50%;" />
 
 A new project will be created with the following structure.
 
-<img src="/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/project-structure.png" alt="project-structure" style="zoom: 50%;" />
+<img src="/docs/advanced-tutorial/images/project-structure.png" alt="project-structure" style="zoom: 50%;" />
 
 The folders are:
 
@@ -43,10 +43,10 @@ Some of the important files are:
 
 Press the debug button top right of the IDE to compile and run the project.
 
-![debug-button](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/debug-button.png)
+![debug-button](/docs/advanced-tutorial/images/debug-button.png)
 
 This will show a Window that looks like:
 
-![image-20210310192926578](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/image-20210310192926578.png)
+![image-20210310192926578](/docs/advanced-tutorial/images/image-20210310192926578.png)
 
 A little plain but we now have a running application, and a blank canvas to start from.

--- a/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/display-images.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/display-images.md
@@ -145,5 +145,5 @@ Ok run the application and search for your favourite artist.
 
 Notice how the Albums covers load one by one, but that the UI remains responsive.
 
-![image-20210310173858088](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/image-20210310173858088.png)
+![image-20210310173858088](/docs/advanced-tutorial/images/image-20210310173858088.png)
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/index.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/index.md
@@ -1,11 +1,11 @@
 ---
 Title: Advanced Tutorial
-Order: 0
+Order: 7
 ---
 
 # Avalonia Music Store Tutorial
 
- Today we will show you how easy it is to build great looking visual desktop applications using JetBrains Rider and Avalonia.
+ Today we will show you how easy it is to build great looking visual desktop applications using JetBrains Rider and Avalonia. The full source for this tutorial can be found at https://github.com/AvaloniaUI/Avalonia.MusicStore.
 
 This guide has instructions for Rider on OSX, however the steps will be almost the same on other operating systems, and reasonably similar on other IDEs such as Visual Studio.
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/initialisation.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/initialisation.md
@@ -30,7 +30,7 @@ As you can see it firstly uses the buisness logic apis to load the list of `Albu
 
 Note we then re-iterate over the `Albums` and asynchronously load each cover. Note that we do this after adding all the albums to the list, as its more important to quickly show the user all the albums available and then load the images. 
 
-![image-20210310184202271](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/image-20210310184202271.png)
+![image-20210310184202271](/docs/advanced-tutorial/images/image-20210310184202271.png)
 
 
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/opening-dialog.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/opening-dialog.md
@@ -13,11 +13,11 @@ In this section we shall make it so that clicking the Store Button opens a `moda
 
 When prompted name this MusicStoreWindow and press the `Enter` key.
 
-![add-window](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/add-window.png)
+![add-window](/docs/advanced-tutorial/images/add-window.png)
 
 This will add the following code:
 
-```xaml
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -31,7 +31,7 @@ This will add the following code:
 
 Change this code as follows to enable the Acrylic and extended client area so the Window will look like our `MainWindow`.
 
-```xaml
+```xml
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -206,6 +206,6 @@ Also set `Width` and `Height`  properties of the `MusicStoreWindows` `<Window>` 
 
 Now run the application and click the Store button.
 
- ![dialog-opened](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/dialog-opened.png)
+ ![dialog-opened](/docs/advanced-tutorial/images/dialog-opened.png)
 
 As you can see the dialog window is opened perfectly centered inside the MainWindow.

--- a/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/searching-albums.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/searching-albums.md
@@ -21,7 +21,7 @@ This will open the `Packages` tool at the bottom of the IDE, like so.
 
 Search for `ItunesSearch` and press the green `+` button on the right hand side to install it.
 
-![image-20210310013703557](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/image-20210310013703557.png)
+![image-20210310013703557](/docs/advanced-tutorial/images/image-20210310013703557.png)
 
 
 
@@ -221,5 +221,5 @@ SearchResults.Add(new AlbumViewModel());
 
 Now run the application and click the store button, then search for an artist or album name. If all has gone to plan you should see the progressbar animating whilst the server is busy processing the request and then you should see some results appear in the list.
 
-![image-20210310110401944](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/image-20210310110401944.png)
+![image-20210310110401944](/docs/advanced-tutorial/images/image-20210310110401944.png)
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/setup.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/setup.md
@@ -48,19 +48,19 @@ Order: 1
 
    Once Rider loads you will see the Welcome Screen. Click the `Configure` dropdown and select `Plugins`. 
 
-<img src="/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/rider-welcome.png" alt="rider-welcome" style="zoom:50%;" />
+<img src="/docs/advanced-tutorial/images/rider-welcome.png" alt="rider-welcome" style="zoom:50%;" />
 
 A new Preferenes Screen will open up. Click the `Settings` icon as shown and select `Manage Plugin Repositories...`
 
-![configure-plugin-repos](/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/configure-plugin-repos.png)
+![configure-plugin-repos](/docs/advanced-tutorial/images/configure-plugin-repos.png)
 
 Click the `+` icon and enter the url `https://plugins.jetbrains.com/plugins/dev/14839`then click `OK`
 
-<img src="/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/enter-plugin-repo.png" alt="enter-plugin-repo" style="zoom:50%;" />
+<img src="/docs/advanced-tutorial/images/enter-plugin-repo.png" alt="enter-plugin-repo" style="zoom:50%;" />
 
 Now click on the `Marketplace` tab and search for `Avalonia`. Select `AvaloniaRider` and click `Install` then once thats done, click the `Restart IDE` button that will appear.
 
-<img src="/Users/danwalmsley/repos/avaloniaui.net/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/images/plugin-install.png" alt="plugin-install" style="zoom:50%;" />
+<img src="/docs/advanced-tutorial/images/plugin-install.png" alt="plugin-install" style="zoom:50%;" />
 
 
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/summary.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/advanced-tutorial/summary.md
@@ -7,7 +7,7 @@ Order: 13
 
 In this tutorial we have shown how Avalonia can be used to create engaging desktop applications. Although we have covered a lot of ground, this is only a small amount of what Avalonia can do. With Avalonia your imagination really is the only limit. 
 
-I hope you have enjoyed building this demo application and please get in touch or send a PR with improvements to the tutorial as it will help many others.
+I hope you have enjoyed building this demo application and please get in touch or send a PR with improvements to the tutorial as it will help many others. The repository can be found at https://github.com/AvaloniaUI/Avalonia.MusicStore.
 
 Welcome to the Avalonia Community.
 

--- a/src/AvaloniaUI.Net/wwwroot/docs/input/events.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/input/events.md
@@ -221,7 +221,7 @@ The Avalonia input system uses attached events extensively. However, nearly all 
 
 Another syntax usage that resembles *typename*.*eventname* attached event syntax but is not strictly speaking an attached event usage is when you attach handlers for routed events that are raised by child elements. You attach the handlers to a common parent, to take advantage of event routing, even though the common parent might not have the relevant routed event as a member. Consider this example again:
 
-```xaml
+```xml
 <Border Height="50" Width="300">
   <StackPanel Orientation="Horizontal" Button.Click="CommonClickHandler">
     <Button Name="YesButton">Yes</Button>

--- a/src/AvaloniaUI.Net/wwwroot/docs/tutorial/index.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/tutorial/index.md
@@ -1,6 +1,6 @@
 ---
 Title: Tutorial
-Order: 0
+Order: 5
 ---
 In this tutorial we're going to be creating a simple TODO application in Avalonia using the Model-View-ViewModel (MVVM) pattern.
 


### PR DESCRIPTION
A few fixes to the Advanced Tutorial:

- Fix article ordering
- Fix XAML code blocks
- Fix some image links which referred to @danwalmsley's local machine
- Add link to the tutorial repo

Also a more general fix:

- Display the documentation article title in browser title bar