### PR TITLE
Fix CFBundlePackageType

### DIFF
--- a/src/AvaloniaUI.Net/wwwroot/docs/packing/macOS.md
+++ b/src/AvaloniaUI.Net/wwwroot/docs/packing/macOS.md
@@ -110,7 +110,7 @@ Instead of specifying `CFBundleDisplayName`, etc., on the command line, you can 
     <CFBundleDisplayName>MyBestThingEver</CFBundleDisplayName>
     <CFBundleIdentifier>com.example</CFBundleIdentifier>
     <CFBundleVersion>1.0.0</CFBundleVersion>
-    <CFBundlePackageType>AAPL</CFBundlePackageType>
+    <CFBundlePackageType>APPL</CFBundlePackageType>
     <CFBundleSignature>????</CFBundleSignature>
     <CFBundleExecutable>AppName</CFBundleExecutable>
     <CFBundleIconFile>AppName.icns</CFBundleIconFile> <!-- Will be copied from output directory -->


### PR DESCRIPTION
I don't know if it's a typo or anything, but [CFBundlePackageType](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundlepackagetype) says `For apps, the code is APPL`. And the [Bundle Structures](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html) says `For applications, the value of this key is always the four-character string APPL.`

I've also created PR to [dotnet-bundle](https://github.com/egramtel/dotnet-bundle/pull/6).

**What kind of change does this PR introduce?**

`AAPL` -> `APPL`
